### PR TITLE
Fix for PM-1135 pegasus.transfer.bypass.input.staging breaks symlinking

### DIFF
--- a/bin/pegasus-transfer
+++ b/bin/pegasus-transfer
@@ -786,8 +786,12 @@ class FileHandler(TransferHandlerBase):
                     self._post_transfer_attempt(t, True, t_start)
                     continue
 
-            cmd = "/bin/cp -f -R -L '%s' '%s'" \
-                % (t.get_src_path(), t.get_dst_path())
+            if symlink_file_transfer:
+                cmd = "ln -f -s '%s' '%s'" \
+                    % (t.get_src_path(), t.get_dst_path())
+            else:
+                cmd = "/bin/cp -f -R -L '%s' '%s'" \
+                    % (t.get_src_path(), t.get_dst_path())
             try:
                 tc = TimedCommand(cmd)
                 tc.run()
@@ -3245,6 +3249,9 @@ logger = logging.getLogger("my_logger")
 # threads we have currently running
 threads = []
 
+# should file transfers symlink rather than copy
+symlink_file_transfer = False
+
 # track remote directories created so that don't have to
 # try to create them over and over again
 remote_dirs_created = {}
@@ -3600,6 +3607,7 @@ def main():
     global threads
     global stats_start
     global stats_end
+    global symlink_file_transfer
     
     # dup stderr onto stdout
     sys.stderr = sys.stdout
@@ -3622,6 +3630,12 @@ def main():
                              " via the PEGASUS_TRANSFER_THREADS environment" +
                              " variable. The command line option takes" +
                              " precedence over the environment variable.")
+    parser.add_option("-s", "--symlink", action = "store_true", dest = "symlink",
+                      help = "Allow symlinking of file URLs." +
+                             " If the source and destination URLs chosen" +
+                             " are both file URLs with the same site_label" +
+                             " then the source file will be symlinked" +
+                             " to the destination rather than being copied.")
     parser.add_option("-d", "--debug", action = "store_true", dest = "debug",
                       help = "Enables debugging ouput.")
     
@@ -3658,6 +3672,9 @@ def main():
     except Exception, err:
         logger.critical('Error reading transfer list: %s' % (err))
         myexit(1)
+
+    # store symlink option in global variable
+    symlink_file_transfer = options.symlink
     
     # queues to track the work
     inputs_l = []

--- a/src/edu/isi/pegasus/planner/code/gridstart/PegasusLite.java
+++ b/src/edu/isi/pegasus/planner/code/gridstart/PegasusLite.java
@@ -915,6 +915,11 @@ public class PegasusLite implements GridStart {
             if( job.userExecutablesStagedForJob() ){
                 appendStderrFragment( sb, "setting the xbit for executables staged" );
                 sb.append( "# set the xbit for any executables staged" ).append( '\n' );
+                if ( mUseSymLinks ){
+                    //PM-1135 if the user does not own the target of the
+                    //symlink then the chmod could fail, so allow this.
+                    sb.append("set +e" ).append( '\n' );
+                }
                 sb.append( getPathToChmodExecutable( job.getSiteHandle() ) );
                 sb.append( " +x " );
 
@@ -926,6 +931,9 @@ public class PegasusLite implements GridStart {
 
                 }
                 sb.append( '\n' );
+                if ( mUseSymLinks ){
+                    sb.append("set -e" ).append( '\n' );
+                }
                 sb.append( '\n' );
             }
            

--- a/src/edu/isi/pegasus/planner/code/gridstart/PegasusLite.java
+++ b/src/edu/isi/pegasus/planner/code/gridstart/PegasusLite.java
@@ -292,6 +292,12 @@ public class PegasusLite implements GridStart {
      */
     protected boolean mEnforceStrictChecksOnWPVersion;
     
+    /**
+     * This member variable if set causes the destination URL for the symlink jobs
+     * to have symlink:// url if the pool attributed associated with the pfn
+     * is same as a particular jobs execution pool. 
+     */
+    protected boolean mUseSymLinks;
     
     /**
      * Whether PegasusLite should download from the worker package from website
@@ -322,6 +328,7 @@ public class PegasusLite implements GridStart {
                 mWorkerPackageMap = new HashMap<String,String>();
         }
         mEnforceStrictChecksOnWPVersion = mProps.enforceStrictChecksForWorkerPackage();
+        mUseSymLinks                    = mProps.getUseOfSymbolicLinks();
         mAllowWPDownloadFromWebsite     = mProps.allowDownloadOfWorkerPackageFromPegasusWebsite();
         
         /* PM-810    
@@ -883,6 +890,10 @@ public class PegasusLite implements GridStart {
                     appendStderrFragment( sb, "staging in input data and executables" );
                     sb.append( "# stage in data and executables" ).append( '\n' );
                     sb.append(  sls.invocationString( job, null ) );
+                    if ( mUseSymLinks ){
+                        //PM-1135 allow the transfer executable to symlink input file urls
+                        sb.append( " --symlink " );
+                    }
                     sb.append( " 1>&2" ).append( " << 'EOF'" ).append( '\n' );
                     sb.append( convertToTransferInputFormat( inputFiles ) );
                     sb.append( "EOF" ).append( '\n' );


### PR DESCRIPTION
Patch https://github.com/pegasus-isi/pegasus/commit/f8ad37a9ec239e0ce60da5ee0063e09bd131fc1f passes the value of ``pegasus.transfer.links`` down to the Python layer by adding the option ``--symlink`` to the invocation of ``pegasus-transfer`` for jobs that transfer the input data in the pegasus lite script. No other transfer jobs are affected, to avoid any problems with files than might be cleaned up later.
This patch assumes that the data in the pegasus scratch directory that the job actually runs in are transient, which should be a safe assumption.

Patch https://github.com/pegasus-isi/pegasus/commit/15292e64d3a7bf64127b4bffc843cbb891be10a7 allows for the case where the symlink points to an executable that the user might not own. In which case the chmod would fail due to bad permissions. If ``pegasus.transfer.links`` is true, we wrap this in a ``set +/-e`` to avoid the whole job aborting.

Patch https://github.com/pegasus-isi/pegasus/commit/37e702f8f7239c17ab614238220b540690774f7d implements the option ``--symlink`` in``pegasus-transfer`` and use ``ln`` rather than ``cp`` if it is set. This is guaranteed to be safe, as if ``cp`` works, then so must ``ln`` and we've already checked that src and dest are not the same inode. 