### PR TITLE
Check that the symlink src exists

### DIFF
--- a/bin/pegasus-transfer
+++ b/bin/pegasus-transfer
@@ -787,6 +787,12 @@ class FileHandler(TransferHandlerBase):
                     continue
 
             if symlink_file_transfer:
+                # first check that the src file exists
+                if os.path.exists(t.get_src_path()) is False:
+                    logger.error("ln: src (%s) does not exist" % t.get_src_path())
+                    failed_l.append(t)
+                    self._post_transfer_attempt(t, False, t_start)
+                    continue
                 cmd = "ln -f -s '%s' '%s'" \
                     % (t.get_src_path(), t.get_dst_path())
             else:


### PR DESCRIPTION
My earlier patch breaks the transfer fallback mechanism, as ``ln`` always works, even if the target does not exists. In this case, the failure happens when the user executable attempts to open the file and not in ``pegasus-transfer``.

This tests that the source of the symlink exists before symlinking it, and fails if it does not. If the source does not exist, ``pegasus-transfer`` will then fall back to the next PFN in the list of possible PFNs.

@rynge sorry, I didn't catch this in testing the earlier patch.
