### PR TITLE
rename java7-devel build requirement to java-devel = 1:1.7.0

### DIFF
--- a/pegasus.spec.in
+++ b/pegasus.spec.in
@@ -11,7 +11,7 @@ Source:         pegasus-%{version}.tar.gz
 
 BuildRoot:      %{_tmppath}/%{name}-root
 
-BuildRequires:  python-setuptools, openssl-devel, pyOpenSSL ant, ant-nodeps, ant-apache-regexp, java7-devel, gcc, groff, python-devel, gcc-c++, make, jpackage-utils, /usr/share/java-1.7.0, asciidoc, libxslt, fop
+BuildRequires:  python-setuptools, openssl-devel, pyOpenSSL ant, ant-nodeps, ant-apache-regexp, java-devel = 1:1.7.0, gcc, groff, python-devel, gcc-c++, make, jpackage-utils, /usr/share/java-1.7.0, asciidoc, libxslt, fop
 Requires:       java, python >= 2.6, condor >= 8.4, graphviz, pyOpenSSL
 
 %define sourcedir %{name}-%{version}


### PR DESCRIPTION
We had compatability shim packages (osg-java7-compat) in the osg to
handle some cases where java7-devel wasn't being provided by the
upstream java packages, but we want to drop osg-java7-compat in OSG 3.4,
so we are switching over to more standard java virtual requirement names
(java/java-devel = 1:1.7.0 instead of java7/java7-devel) which are
available across the board.

https://jira.opensciencegrid.org/browse/SOFTWARE-2991