### PR TITLE
OSG spec file updates

### DIFF
--- a/pegasus.spec.in
+++ b/pegasus.spec.in
@@ -9,7 +9,10 @@ Packager:       Pegasus Development Team <pegasus-support@isi.edu>
 
 Source:         pegasus-%{version}.tar.gz
 
-BuildRequires:  python-setuptools, openssl-devel, pyOpenSSL ant, ant-nodeps, ant-apache-regexp, java-devel = 1:1.7.0, gcc, groff, python-devel, gcc-c++, make, jpackage-utils, /usr/share/java-1.7.0, asciidoc, libxslt, fop
+BuildRequires:  python-setuptools, openssl-devel, pyOpenSSL ant, ant-apache-regexp, java-devel = 1:1.7.0, gcc, groff, python-devel, gcc-c++, make, jpackage-utils, /usr/share/java-1.7.0, asciidoc, libxslt, fop, R-devel
+%if 0%{?rhel} < 7
+BuildRequires:  ant-nodeps
+%endif
 Requires:       java, python >= 2.6, condor >= 8.4, graphviz, pyOpenSSL
 
 %define sourcedir %{name}-%{version}

--- a/pegasus.spec.in
+++ b/pegasus.spec.in
@@ -9,8 +9,6 @@ Packager:       Pegasus Development Team <pegasus-support@isi.edu>
 
 Source:         pegasus-%{version}.tar.gz
 
-BuildRoot:      %{_tmppath}/%{name}-root
-
 BuildRequires:  python-setuptools, openssl-devel, pyOpenSSL ant, ant-nodeps, ant-apache-regexp, java-devel = 1:1.7.0, gcc, groff, python-devel, gcc-c++, make, jpackage-utils, /usr/share/java-1.7.0, asciidoc, libxslt, fop
 Requires:       java, python >= 2.6, condor >= 8.4, graphviz, pyOpenSSL
 
@@ -39,7 +37,6 @@ strip dist/pegasus-%{version}/bin/pegasus-kickstart
 strip dist/pegasus-%{version}/bin/pegasus-keg
 
 %install
-rm -Rf %{buildroot}
 
 mkdir -p %{buildroot}/%{_sysconfdir}/%{name}
 mkdir -p %{buildroot}/%{_bindir}
@@ -56,11 +53,6 @@ rm -f %{buildroot}/%{_datadir}/%{name}/java/COPYING.*
 rm -f %{buildroot}/%{_datadir}/%{name}/java/EXCEPTIONS.*
 rm -f %{buildroot}/%{_datadir}/%{name}/java/LICENSE.*
 rm -f %{buildroot}/%{_datadir}/%{name}/java/NOTICE.*
-
-%clean
-ant clean
-rm -Rf %{buildroot}
-
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
We needed to adjust a couple build requirements in order to build in the OSG.

We also drop obsolete spec file items that were only relevant for RHEL5 and older.

https://jira.opensciencegrid.org/browse/SOFTWARE-3103
https://jira.opensciencegrid.org/browse/SOFTWARE-3050