### PR TITLE
Fix a bug in the way the container name is written

### DIFF
--- a/lib/pegasus/python/Pegasus/catalogs/transformation_catalog.py
+++ b/lib/pegasus/python/Pegasus/catalogs/transformation_catalog.py
@@ -113,7 +113,9 @@ class TransformationCatalog:
 
                         # reference to container
                         if e.container:
-                            ppf.write('\t\tcontainer "%s"\n' % e.container)
+                            ppf.write('\t\tcontainer "%s"\n' %
+                                      e.container.name
+                            )
 
                         ppf.write('\t}\n')
 


### PR DESCRIPTION
Writing `e.container` puts `container "<Container inspiral-container:singularity>"` into the transformation catalog. This fix writes `container "inspiral-container"`