### PR TITLE
Copy credentials into container workdir

### DIFF
--- a/share/pegasus/sh/pegasus-lite-common.sh
+++ b/share/pegasus/sh/pegasus-lite-common.sh
@@ -293,6 +293,22 @@ function container_init()
     cont_group=`id -g -n $cont_user` 
     cont_name=${PEGASUS_DAG_JOB_ID}-`date -u +%s`
 
+    # copy credentials into the pwd as this will become the container directory
+    for base in X509_USER_PROXY S3CFG BOTO_CONFIG SSH_PRIVATE_KEY irodsEnvFile GOOGLE_PKCS12 ; do
+        for key in `(env | grep -i ^$base | sed 's/=.*//') 2>/dev/null`; do
+            eval val="\$$key"
+            cred="`basename ${val}`"
+            dest="`pwd`/${cred}"
+            if [ ! -f $dest ] ; then
+                cp $val $dest
+                chmod 600 $dest
+                pegasus_lite_log "Copied credential \$$key to $dest"
+                eval $key=$dest
+                eval val="\$$key"
+                pegasus_lite_log "Set \$$key to $val"
+            fi
+        done
+    done
 }
 
 function docker_init()

--- a/src/edu/isi/pegasus/planner/code/gridstart/container/impl/Singularity.java
+++ b/src/edu/isi/pegasus/planner/code/gridstart/container/impl/Singularity.java
@@ -168,6 +168,7 @@ public class Singularity extends Abstract{
         sb.append( "\n" );
         sb.append( "cat <<EOF > " ).append( scriptName ).append( "\n" );
         sb.append( "#!/bin/bash" ).append( "\n" );
+        appendStderrFragment( sb, Abstract.CONTAINER_MESSAGE_PREFIX, "Now in pegasus lite container script" );
         sb.append( "set -e" ).append( "\n" );
         
         //set the job environment variables explicitly in the -cont.sh file
@@ -237,6 +238,7 @@ public class Singularity extends Abstract{
         sb.append( "set -e" ).append( '\n' );//PM-701
         sb.append( super.outputFilesToPegasusLite(job) );
 
+        appendStderrFragment( sb, Abstract.CONTAINER_MESSAGE_PREFIX, "Exiting pegasus lite container script" );
         sb.append( "EOF").append( "\n" );
         sb.append( "\n" );
         sb.append( "\n" );


### PR DESCRIPTION
Rebases https://github.com/pegasus-isi/pegasus/pull/15 against the 4.9 branch.

This fixes the handling of credentials inside container jobs. Before initializing the container, any credentials are copied into the PWD when `container_init()` is run. Since this function is run after `pegasus_lite_setup_work_dir`, then PWD will be correct for the container's base directory.

Together with the fix in https://github.com/pegasus-isi/pegasus/commit/c249271af4afd8fbd148101cffab7774a68d5b24, the sequence is:

1. If `x509userproxy = /tmp/x509up_u620` is set in the condor submit file, then condor will stage the credential to the job's execution directory and set `X509_USER_PROXY` to this value.
2. The invocation of `pegasus_lite_init` on the execute node sets up the credentials as before for transfer jobs outside the container.
3. The invocation of `pegasus_lite_setup_work_dir` changes the PWD to the pegasus scratch directory.
4. With this fix, the invocation of `singularity_init` or `docker_init` calls `container_init()` which copies the credential file from value given in the environment (as fixed by `singularity_init`) to the current PWD, which become be the base directory of the container.
5. The invocation of `pegasus_lite_init` inside the container sets the credential correctly for use in the container.