### PR TITLE
Don't unset TMPDIR when before checking for space

### DIFF
--- a/share/pegasus/sh/pegasus-lite-common.sh
+++ b/share/pegasus/sh/pegasus-lite-common.sh
@@ -225,7 +225,6 @@ function pegasus_lite_setup_work_dir()
     fi
 
     targets="$PEGASUS_WN_TMP $_CONDOR_SCRATCH_DIR $OSG_WN_TMP $TG_NODE_SCRATCH $TG_CLUSTER_SCRATCH $SCRATCH $TMPDIR $TMP /tmp"
-    unset TMPDIR
 
     if [ "x$PEGASUS_WN_TMP_MIN_SPACE" = "x" ]; then
         PEGASUS_WN_TMP_MIN_SPACE=1000000


### PR DESCRIPTION
`pegasus_lite_setup_work_dir()` unsets `TMPDIR` before it starts looking for free space. This prevents the user passing a `TMPDIR` environment variable to their job.

I don't see any uses of `mktemp` that would rely on `TMPDIR` being unset and I don't see any code that re-sets it, so I think this line should be removed.

This was triggered by trying to weave compile code inside a Singularity container. Weave wants to use `/tmp` which causes an error, so I need to set `TMPDIR` to `/srv`