### PR TITLE
Stage condor credentials into the container

### DIFF
--- a/share/pegasus/sh/pegasus-lite-common.sh
+++ b/share/pegasus/sh/pegasus-lite-common.sh
@@ -293,14 +293,14 @@ function container_env()
     inside_work_dir=$1
 
     # copy credentials into the pwd as this will become the container directory
-    for base in X509_USER_PROXY S3CFG BOTO_CONFIG SSH_PRIVATE_KEY irodsEnvFile GOOGLE_PKCS12 ; do
+    for base in X509_USER_PROXY S3CFG BOTO_CONFIG SSH_PRIVATE_KEY irodsEnvFile GOOGLE_PKCS12 _CONDOR_CREDS ; do
         for key in `(env | grep -i ^$base | sed 's/=.*//') 2>/dev/null`; do
             eval val="\$$key"
             cred="`basename ${val}`"
             dest="`pwd`/$cred"
             dest_inside="$inside_work_dir/$cred"
-            if [ ! -f $dest ] ; then
-                cp $val $dest
+            if [ ! -e $dest ] ; then
+                cp -R $val $dest
                 chmod 600 $dest
                 pegasus_lite_log "Copied credential \$$key to $dest"
                 echo "export $key=\"$dest_inside\""


### PR DESCRIPTION
`stashcp` looks for Condor credentials in the current folder, so this copies them into the container. Since `_CONDOR_CREDS` is a directory, I changed `-f` to -`e` and added `-R` to the cp.

Here's the code from stashcp:

```python
    if '_CONDOR_CREDS' in os.environ:
        # First, look for the scitokens.use file
        # Format: _CONDOR_CREDS=/var/lib/condor/execute/dir_908/.condor_creds
        scitoken_file = os.path.join(os.environ['_CONDOR_CREDS'], 'scitokens.use')
        if not os.path.exists(scitoken_file):
            scitoken_file = None

    if not scitoken_file and os.path.exists(".condor_creds/scitokens.use"):
        scitoken_file = ".condor_creds/scitokens.use"

    if not scitoken_file:
        logging.error("Unable to find scitokens.use file")
        return 1
```