### PR TITLE
Use subprocess module for shell calls, not commands

### DIFF
--- a/lib/pegasus/python/Pegasus/tools/utils.py
+++ b/lib/pegasus/python/Pegasus/tools/utils.py
@@ -29,7 +29,6 @@ import errno
 import shutil
 import logging
 import calendar
-import commands
 import datetime
 import traceback
 import subprocess
@@ -394,7 +393,7 @@ def version():
     """
     Obtains Pegasus version
     """
-    my_output = commands.getstatusoutput("pegasus-version")
+    my_output = subprocess.check_output("pegasus-version")
 
     return my_output[1]
 


### PR DESCRIPTION
This PR updates `Pegasus.tools.utils` to use `subprocess`, and not `commands`, which was removed for python3.

The used `subprocess.check_output` function was introduced for python-2.7, I don't know what I need to do to reflect that new minimum version in other files.