### PR TITLE
Fixed import of flask_cache.Cache

### DIFF
--- a/lib/pegasus/python/Pegasus/service/__init__.py
+++ b/lib/pegasus/python/Pegasus/service/__init__.py
@@ -36,7 +36,7 @@ def get_pegasus_home():
     return None
 
 
-from flask.ext.cache import Cache
+from flask_cache import Cache
 cache = Cache(app)
 
 #


### PR DESCRIPTION
This PR fixes the import of `flask_cache` when using `flask >=1.0.0`. This is backwards-compatible with `flask-cache-0.13.1`.