### PR TITLE
Proposed fix for PM-1360

### DIFF
--- a/src/edu/isi/pegasus/planner/code/gridstart/NoGridStart.java
+++ b/src/edu/isi/pegasus/planner/code/gridstart/NoGridStart.java
@@ -39,6 +39,7 @@ import edu.isi.pegasus.planner.transfer.SLS;
 import edu.isi.pegasus.planner.transfer.sls.SLSFactory;
 
 import edu.isi.pegasus.planner.namespace.Pegasus;
+import edu.isi.pegasus.planner.common.PegasusConfiguration;
 
 import java.io.File;
 
@@ -588,9 +589,16 @@ public class NoGridStart implements GridStart {
      * @return
      */
     protected boolean requiresToSetDirectory( Job job ) {
-        //the cleanup jobs should never have directory set as full path
-        //is specified
-        return ( job.getJobType() != Job.CLEANUP_JOB );
+        String conf = job.getDataConfiguration();
+        if ( job.getJobType() == Job.CLEANUP_JOB ) {
+            //the cleanup jobs should never have directory set as full path
+            //is specified
+            return false;
+        } else if ( conf != null && conf.equalsIgnoreCase( PegasusConfiguration.CONDOR_CONFIGURATION_VALUE) ) {
+            // don't set remote_initialdir for condorio jobs
+            return false;
+        }
+        return true;
     }
     
     /**

--- a/src/edu/isi/pegasus/planner/transfer/sls/SLSFactory.java
+++ b/src/edu/isi/pegasus/planner/transfer/sls/SLSFactory.java
@@ -23,6 +23,7 @@ import edu.isi.pegasus.planner.classes.PegasusBag;
 import edu.isi.pegasus.planner.transfer.SLS;
 
 import edu.isi.pegasus.planner.common.PegasusProperties;
+import edu.isi.pegasus.common.logging.LogManager;
 import edu.isi.pegasus.common.util.DynamicLoader;
 import edu.isi.pegasus.planner.classes.Job;
 import edu.isi.pegasus.planner.common.PegasusConfiguration;
@@ -64,11 +65,16 @@ public class SLSFactory {
                                                      "Transfer",
                                                      "Condor"
                                                     };
+
+    /**
+     * The handle to the logging manager.
+     */
+    protected LogManager mLogger;
+    
     private final HashMap mSLSImplementationTable;
     private boolean mInitialized;
     private PegasusBag mBag;
-    
-    
+
     /**
      * The default constructor.
      */
@@ -85,6 +91,7 @@ public class SLSFactory {
      */
     public void initialize( PegasusBag bag ){
         mBag       = bag;
+        mLogger    = bag.getLogger();
 
         //load all the known implementations and initialize them
         for( int i = 0; i < SLS_IMPLEMENTING_CLASSES.length; i++){
@@ -125,6 +132,7 @@ public class SLSFactory {
 
         //determine the short name of SLS implementation
         String shortName = this.getSLSShortName(job);
+        mLogger.log(job.getName() + " uses SLS " + shortName, LogManager.DEBUG_MESSAGE_LEVEL);
 
         //try loading on the basis of short name from the cache
         Object obj = this.mSLSImplementationTable.get( shortName );


### PR DESCRIPTION
This is a proposed fix for [PM-1360](https://jira.isi.edu/projects/PM/issues/PM-1360) and adds a call to the SLS factory in NoGridStart so `transfer_input_files` and `transfer_output_files` are populated correctly when using `condorio` and `NoGridStart` for a job.

