### PR TITLE
Add space when using PEGASUS_LITE_ENV_SOURCE_KEY for sub-workflows

### DIFF
--- a/src/edu/isi/pegasus/planner/code/gridstart/PegasusLite.java
+++ b/src/edu/isi/pegasus/planner/code/gridstart/PegasusLite.java
@@ -781,7 +781,7 @@ public class PegasusLite implements GridStart {
             boolean relyOnPegasusLiteToSetupWorkerPackage = true;
             if (job instanceof DAXJob) {
                 if (job.getSiteHandle().equals("local")) {
-                    sb.append("# set for pegasus-plan invocation ").append('\n');
+                    sb.append(" # set for pegasus-plan invocation ").append('\n');
                     sb.append("export PEGASUS_HOME")
                             .append("=\"")
                             .append(this.mProps.getBinDir().getParentFile().getAbsolutePath())


### PR DESCRIPTION
When using PEGASUS_LITE_ENV_SOURCE_KEY in pegasus 5 pegasus-plan jobs contain a line reading:

```
. $PEGASUS_LITE_ENV_SOURCE# set for pegasus-plan invocation
```

A space is needed before the comment otherwise this gets mangled.

.... This is part of trying to get pegasus 5 working with the PyCBC repository. I'll send more details direct to Karan by email, but this seemed a quick fix!