### PR TITLE
Debian fixes: build 5.0.0 Stretch-Buster-Bullseye

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,9 +17,11 @@ Build-Depends: debhelper (>= 9),
        python3-setuptools,
        python3-yaml,
        r-base-dev,
-       zlib1g-dev
+       zlib1g-dev,
+       python3-sphinx,
+       python3-setuptools-scm
 Standards-Version: 3.9.4
-X-Python-Version: >= 2.7
+X-Python3-Version: >= 3.5
 Homepage: https://pegasus.isi.edu
 
 Package: pegasus

--- a/share/pegasus/sh/pegasus-lite-common.sh
+++ b/share/pegasus/sh/pegasus-lite-common.sh
@@ -619,6 +619,18 @@ pegasus_lite_get_system()
                 "sles") osname="suse" ;;
                 *) osname="$osname" ;;
             esac
+	    
+	    if [ "$osname" = "deb" -a -z "$osversion" ]
+	    then
+	    	oscodename=`cat /etc/debian_version | cut -d/ -f1`
+		case $oscodename in
+		    "buster")	osversion="10" ;;
+		    "bullseye")	osversion="11" ;;
+		    "bookworm")	osversion="12" ;;
+		    "trixie")	osversion="13" ;;
+		esac
+	    fi
+
         elif [ -e /etc/issue ]; then
             osname=`cat /etc/issue | head -n1 | awk '{print $1;}' | tr '[:upper:]' '[:lower:]'`
 


### PR DESCRIPTION
Fix Debian builds (also for releases after Buster) - by 

 - adding build dependencies (python3-sphinx, python3-setuptools-scm) and adjusting supported Python versions
 - adding detection of "Debian testing" versions (for getsystem and getosid).
 - 
The former enabled Stretch and Buster builds, the latter has been successfully tested for regressions on those platforms. Debian Bullseye build now succeeds.