### PR TITLE
Use implicit namespace package for pegasus-worker python package

### DIFF
--- a/packages/pegasus-worker/setup.py
+++ b/packages/pegasus-worker/setup.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 src_dir = os.path.dirname(__file__)
 home_dir = os.path.abspath(os.path.join(src_dir, "../.."))
@@ -32,6 +32,21 @@ def read_version():
 #
 def read(fname):
     return open(os.path.join(src_dir, fname)).read()
+
+
+# TODO: Someday remove this method and replace with setuptools.find_namespace_packages
+def find_namespace_packages(where):
+    pkgs = []
+    for root, dirs, _ in os.walk(where):
+        root = root[len(where) + 1 :]
+        for pkg in dirs:
+            if pkg == where or pkg.endswith(".egg-info") or pkg == "__pycache__":
+                continue
+
+            pkgs.append(os.path.join(root, pkg).replace("/", "."))
+
+    return pkgs
+
 
 
 setup(
@@ -66,7 +81,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
     ],
     package_dir={"": "src"},
-    packages=find_packages(where="src"),
+    packages=find_namespace_packages(where="src"),
     include_package_data=True,
     zip_safe=False,
     install_requires=install_requires,

--- a/packages/pegasus-worker/src/Pegasus/__init__.py
+++ b/packages/pegasus-worker/src/Pegasus/__init__.py
@@ -1,1 +1,0 @@
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)


### PR DESCRIPTION
This PR copies the custom `find_namespace_packages` code from `packages/pegasus-common/setup.py` into `pegasus-worker` so that it is properly structured as a namspace package as well.