### PR TITLE
Added support ppc64le architecture for Pegasus 5.0

### DIFF
--- a/src/edu/isi/pegasus/common/util/Version.java
+++ b/src/edu/isi/pegasus/common/util/Version.java
@@ -36,7 +36,7 @@ public class Version {
     /** Basename of the build stamp file. */
     public static final String STAMP_FILENAME = "stamp";
 
-    private static final String mPlatformRegex = "(x86|x86_64|ia64|ppc)_([a-zA-Z0-9]*)_([0-9]*)";
+    private static final String mPlatformRegex = "(x86|x86_64|ia64|ppc|ppc64le)_([a-zA-Z0-9]*)_([0-9]*)";
 
     /** Stores compiled patterns at first use, quasi-Singleton. */
     private static Pattern mPlatformPattern = null;

--- a/src/edu/isi/pegasus/planner/refiner/DeployWorkerPackage.java
+++ b/src/edu/isi/pegasus/planner/refiner/DeployWorkerPackage.java
@@ -794,7 +794,7 @@ public class DeployWorkerPackage extends Engine {
                     Dagman.POST_SCRIPT_KEY, PegasusExitCode.SHORT_NAME);
             setupTXJob.dagmanVariables.construct(
                     Dagman.POST_SCRIPT_ARGUMENTS_KEY,
-                    POSTSCRIPT_ARGUMENTS_FOR_PASSING_DAGMAN_JOB_EXITCODE);
+                    POSTSCRIPT_ARGUMENTS_FOR_ONLY_ROTATING_LOG_FILE);
             */
 
             // PM-1552 after 5.0 worker package organization, we cannot just
@@ -958,7 +958,7 @@ public class DeployWorkerPackage extends Engine {
         setupTXJob.vdsNS.construct(Pegasus.GRIDSTART_KEY, "None");
         // no empty postscript but arguments to exitcode to add -r $RETURN
         setupTXJob.dagmanVariables.construct(
-                Dagman.POST_SCRIPT_ARGUMENTS_KEY, POSTSCRIPT_ARGUMENTS_FOR_PASSING_DAGMAN_JOB_EXITCODE);
+                Dagman.POST_SCRIPT_ARGUMENTS_KEY, POSTSCRIPT_ARGUMENTS_FOR_ONLY_ROTATING_LOG_FILE);
         */
         // PM-1552 after 5.0 worker package organization, we cannot just
         // transfer pegasus-transfer using transfer_executable. Instead we

--- a/src/edu/isi/pegasus/planner/refiner/DeployWorkerPackage.java
+++ b/src/edu/isi/pegasus/planner/refiner/DeployWorkerPackage.java
@@ -103,7 +103,7 @@ public class DeployWorkerPackage extends Engine {
     private static final String mRegexExpression =
             //
             // "(pegasus-)(binary|worker)-([0-9]\\.[0-9]\\.[0-9][a-zA-Z]*)-x86.*";
-            "(pegasus-)(binary|worker)-([0-9]\\.[0-9]\\.[0-9][a-zA-Z0-9]*)-(x86|x86_64|ia64|ppc)_([a-zA-Z0-9]*)_([0-9]*).tar.gz";
+            "(pegasus-)(binary|worker)-([0-9]\\.[0-9]\\.[0-9][a-zA-Z0-9]*)-(x86|x86_64|ia64|ppc|ppc64le)_([a-zA-Z0-9]*)_([0-9]*).tar.gz";
 
     /** The path to be set for create dir jobs. */
     public static final String PATH_VALUE = ".:/bin:/usr/bin:/usr/ucb/bin";
@@ -794,7 +794,7 @@ public class DeployWorkerPackage extends Engine {
                     Dagman.POST_SCRIPT_KEY, PegasusExitCode.SHORT_NAME);
             setupTXJob.dagmanVariables.construct(
                     Dagman.POST_SCRIPT_ARGUMENTS_KEY,
-                    POSTSCRIPT_ARGUMENTS_FOR_ONLY_ROTATING_LOG_FILE);
+                    POSTSCRIPT_ARGUMENTS_FOR_PASSING_DAGMAN_JOB_EXITCODE);
             */
 
             // PM-1552 after 5.0 worker package organization, we cannot just
@@ -958,7 +958,7 @@ public class DeployWorkerPackage extends Engine {
         setupTXJob.vdsNS.construct(Pegasus.GRIDSTART_KEY, "None");
         // no empty postscript but arguments to exitcode to add -r $RETURN
         setupTXJob.dagmanVariables.construct(
-                Dagman.POST_SCRIPT_ARGUMENTS_KEY, POSTSCRIPT_ARGUMENTS_FOR_ONLY_ROTATING_LOG_FILE);
+                Dagman.POST_SCRIPT_ARGUMENTS_KEY, POSTSCRIPT_ARGUMENTS_FOR_PASSING_DAGMAN_JOB_EXITCODE);
         */
         // PM-1552 after 5.0 worker package organization, we cannot just
         // transfer pegasus-transfer using transfer_executable. Instead we


### PR DESCRIPTION
On the Lassen supercomputer in LLNL (which has ppc64le architecture), when we run pegasus for montage workflow, we get the following error:

```
2021.09.23 10:39:47.522 PDT: [FATAL ERROR]  java.lang.RuntimeException: Unable to determine architecture from  ppc64le_rhel_7
	at edu.isi.pegasus.common.util.Version.getArchitecture(Version.java:135)
	at edu.isi.pegasus.planner.common.PegasusConfiguration.constructDefaultLocalSiteEntry(PegasusConfiguration.java:651)
	at edu.isi.pegasus.planner.common.PegasusConfiguration.updateSiteStoreAndOptions(PegasusConfiguration.java:207)
	at edu.isi.pegasus.planner.client.CPlanner.executeCommand(CPlanner.java:428)
	at edu.isi.pegasus.planner.client.CPlanner.executeCommand(CPlanner.java:322)
	at edu.isi.pegasus.planner.client.CPlanner.main(CPlanner.java:209)
```
After fixing the Version.java, we get
```
2021.09.23 10:52:28.544 PDT: [FATAL ERROR]  java.lang.RuntimeException: Unable to determine system information of package from name  pegasus-worker-5.0.1dev-ppc64le_rhel_7.tar.gz
	at edu.isi.pegasus.planner.refiner.DeployWorkerPackage.determineSysInfo(DeployWorkerPackage.java:666)
	at edu.isi.pegasus.planner.refiner.DeployWorkerPackage.getTCEntryForPegasusWorkerPackage(DeployWorkerPackage.java:1375)
	at edu.isi.pegasus.planner.refiner.DeployWorkerPackage.setupTCForWorkerPackageLocations(DeployWorkerPackage.java:410)
	at edu.isi.pegasus.planner.refiner.DeployWorkerPackage.initialize(DeployWorkerPackage.java:375)
	at edu.isi.pegasus.planner.refiner.MainEngine.runPlanner(MainEngine.java:191)
	at edu.isi.pegasus.planner.client.CPlanner.executeCommand(CPlanner.java:611)
	at edu.isi.pegasus.planner.client.CPlanner.executeCommand(CPlanner.java:322)
	at edu.isi.pegasus.planner.client.CPlanner.main(CPlanner.java:209)
```
The patch for these files is present in this PR.