### PR TITLE
Don't exclude tests from python source distributions

### DIFF
--- a/packages/pegasus-api/MANIFEST.in
+++ b/packages/pegasus-api/MANIFEST.in
@@ -1,4 +1,2 @@
 include LICENSE
 include README.md
-
-recursive-exclude test *

--- a/packages/pegasus-common/MANIFEST.in
+++ b/packages/pegasus-common/MANIFEST.in
@@ -1,4 +1,2 @@
 include LICENSE
 include README.md
-
-recursive-exclude test *

--- a/packages/pegasus-python/MANIFEST.in
+++ b/packages/pegasus-python/MANIFEST.in
@@ -1,4 +1,2 @@
 include LICENSE
 include README.md
-
-recursive-exclude test *

--- a/packages/pegasus-worker/MANIFEST.in
+++ b/packages/pegasus-worker/MANIFEST.in
@@ -1,4 +1,2 @@
 include LICENSE
 include README.md
-
-recursive-exclude test *


### PR DESCRIPTION
This PR removes the `recursive-exclude test *` entries from the `MANIFEST.in` for each Python package; having the tests in the distribution can be useful when validating downstream packages or environments.