### PR TITLE
Unpin PyYAML in Python package requirements

### DIFF
--- a/packages/pegasus-common/setup.py
+++ b/packages/pegasus-common/setup.py
@@ -7,7 +7,7 @@ src_dir = os.path.dirname(__file__)
 home_dir = os.path.abspath(os.path.join(src_dir, "../.."))
 
 install_requires = [
-    "PyYAML>5.3,<5.5",
+    "PyYAML>5.3",
 ]
 
 

--- a/packages/pegasus-python/setup.py
+++ b/packages/pegasus-python/setup.py
@@ -9,7 +9,7 @@ home_dir = os.path.abspath(os.path.join(src_dir, "../.."))
 install_requires = [
     # Utils
     # DAX/Workflow
-    "PyYAML>5.3,<5.5",
+    "PyYAML>5.3",
     # pegasus-init
     "GitPython>1.0,<3.2",
     "pamela>=1.0,<1.1",


### PR DESCRIPTION
This PR relaxes the PyYAML requirement for `pegasus-wms.common` and `pegasus-wms` to allow use of PyYAML 6.0, which is the _oldest_ version built for Python 3.10 in conda-forge.

As far as I can tell, all of the tests pass using PyYAML 6.0.