### PR TITLE
Allow sqlalchemy 1.4 with pegasus-wms Python package

### DIFF
--- a/packages/pegasus-python/setup.py
+++ b/packages/pegasus-python/setup.py
@@ -17,7 +17,7 @@ install_requires = [
     "Flask>1.1,<1.2",
     "Flask-Caching>1.8,<1.11",
     "requests>2.23,<2.26",
-    "sqlalchemy>1.3,<1.4",
+    "sqlalchemy>1.3,<1.5",
     "pegasus-wms.api<5.2",
     "pegasus-wms.dax<5.2",
     "pegasus-wms.common<5.2",


### PR DESCRIPTION
This PR relaxes the version constraint on `sqlalchemy` to `>1.3,<1.5`; 1.4.x is the oldest version built against Python 3.10 in conda-forge.