### PR TITLE
PM-1880 Updated the test_get_status

### DIFF
--- a/packages/pegasus-common/test/client/test_client.py
+++ b/packages/pegasus-common/test/client/test_client.py
@@ -504,7 +504,7 @@ class TestClient:
         ],
     )
     def test_get_status(self, mocker, client, status_output_str, expected_dict):
-        mocker.patch(
+        '''mocker.patch(
             "Pegasus.client._client.Client._exec",
             return_value=Result(
                 cmd=["/path/bin/pegasus-status", "--long", "submit_dir"],
@@ -512,8 +512,10 @@ class TestClient:
                 stdout_bytes=status_output_str,
                 stderr_bytes=b"",
             ),
-        )
+        )'''
+        mocker.patch("Pegasus.client.status.Status.fetch_status", return_value=expected_dict)
         assert client.get_status("wf-name", "submit_dir") == expected_dict
+        Pegasus.client.status.Status.fetch_status.assert_called_once_with("submit_dir", json=True)
 
     @pytest.mark.parametrize(
         "status_output, expected_progress_bar",


### PR DESCRIPTION
get_status function was changed in _client.py to use Python status API returning dict directly. Earlier console output was being parsed to return the dict, thus test is changed.