### PR TITLE
Adds a "local_submit_attributes.sh" script for the Flux RJMS

### DIFF
--- a/share/pegasus/htcondor/glite/flux_local_submit_attributes.sh
+++ b/share/pegasus/htcondor/glite/flux_local_submit_attributes.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+strip_quotes() {
+    echo ${1//\"/}
+}
+
+if [ -n "${WALLTIME}" ]; then
+    echo "#FLUX: --time-limit=$(strip_quotes $WALLTIME)"
+fi
+
+# Add if/when Flux allows users to specify memory
+# if [ -n "${PER_PROCESS_MEMORY}" ]; then
+#     echo "#SBATCH --mem-per-cpu=$(strip_quotes $PER_PROCESS_MEMORY)"
+# fi
+
+# Add if/when Flux allows users to specify memory
+# if [ -n "${TOTAL_MEMORY}" ]; then
+#     echo "#SBATCH --mem=$(strip_quotes $TOTAL_MEMORY)"
+# fi
+
+if [ -n "${JOBNAME}" ]; then
+    echo "#FLUX: --job-name=${JOBNAME}"
+fi
+
+if [ -n "${PROJECT}" ]; then
+    echo "#FLUX: --bank=${PROJECT}"
+fi
+
+if [ "x${EXCLUSIVE}" == "xyes" ]; then
+    echo "#FLUX: --exclusive"
+fi
+
+# if a user passed any extra arguments set them in the end
+# for example "-N testjob -l walltime=01:23:45 -l nodes=2"
+if [ -n "${EXTRA_ARGUMENTS}" ]; then
+    echo "#FLUX: $(strip_quotes "$EXTRA_ARGUMENTS")"
+fi
+
+# This logic is all duplicated from 'flux_submit.sh'. The only difference
+# is the naming of the inputs. Namely, inputs to this script map to inputs in
+# 'flux_submit.sh' as follows:
+#   * NODES -> bls_opt_hostnumber
+#   * PROCS -> bls_opt_smpgranularity
+#   * CORES -> bls_opt_mpinodes
+#   * GPUS -> bls_opt_gpunumber
+local __flux_nnodes=
+local __flux_nslots=
+local __flux_ncores_per_slot=
+local __flux_ngpus_per_slot=
+
+if [ -n "${NODES}" ] || ([ -n "${PROCS}" ] && [ -n "${CORES}" ]); then
+    if [ -n "${NODES}" ]; then
+        __flux_nnodes=${NODES}
+    else
+        __flux_nnodes=$(( (CORES + PROCS - 1) / PROCS ))
+    fi
+    local __cores_per_slot_from_CORES=
+    if [ -n "${CORES}" ]; then
+        __cores_per_slot_from_CORES=$(( (CORES + __flux_nnodes - 1) / __flux_nnodes ))
+    fi
+    if [ ! -z "${__cores_per_slot_from_CORES}" ] && [ -n "${PROCS}" ]; then
+        if [ "${__cores_per_slot_from_CORES}" -ge "${PROCS}" ]; then
+            __flux_ncores_per_slot=${__cores_per_slot_from_CORES}
+        else
+            __flux_ncores_per_slot=${PROCS}
+        fi
+    elif [ ! -z "${__cores_per_slot_from_CORES}" ]; then
+        __flux_ncores_per_slot=${__cores_per_slot_from_CORES}
+    elif [ -n "${PROCS}" ]; then
+        __flux_ncores_per_slot=${PROCS}
+    fi
+    __flux_nslots=${__flux_nnodes}
+elif [ -n "${CORES}" ]; then
+    __flux_nslots=${CORES}
+    __flux_ncores_per_slot=1
+fi
+
+if [ -n "${NODES}" ]; then
+    nodes="#FLUX: --nodes=$(strip_quotes $NODES)"
+    echo $nodes
+fi
+
+if [ ! -z "${__flux_nnodes}" ]; then
+    echo "#FLUX: --nodes=$(strip_quotes ${__flux_nnodes})"
+fi
+if [ ! -z "${__flux_nslots}" ]; then
+    echo "#FLUX: --nslots=$(strip_quotes ${__flux_nslots})"
+fi
+if [ ! -z "${__flux_ncores_per_slot}" ]; then
+    echo "#FLUX: --cores-per-slot=$(strip_quotes ${__flux_ncores_per_slot})"
+fi
+if [ ! -z "${__flux_nnodes}" ] && [ -n "${GPUS}" ]; then
+    echo "#FLUX: --gpus-per-slot=$(strip_quotes ${GPUS})"
+fi
+


### PR DESCRIPTION
This PR adds a "local submit attributes" script (i.e., `flux_local_submit_attributes.sh`) to Pegasus to enable submitting workflow tasks to LLNL's [Flux resource manager](https://flux-framework.org/), which is the resource and job management system (RJMS) for the El Capitan and Tuolumne supercomputers.

This PR, combined with some in-progress changes from @vahi and [my HTCondor PR enabling Flux](https://github.com/htcondor/htcondor/pull/3870), will allow Pegasus to run on a wide variety of systems, including:
* El Capitan, Tuolumne, and other systems using Flux as their system-wide RJMS
* Systems where Flux is available for "user-mode" deployments (e.g., Frontier and all systems at LLNL, LANL, and Sandia)
* Kubernetes clusters in the cloud through the [Flux Operator](https://flux-framework.org/flux-operator/)

This Flux support will also enable Pegasus users to avoid scheduling contention on HPC clusters without having to use the `pegasus-mpi-cluster` (PMC). Due to Flux's hierarchical scheduling capabilities, users can get one big allocation for their workflow (similar to what they'd do for PMC), and then Pegasus and HTCondor can just submit jobs to the Flux instance over that allocation, which is owned by the user and does not contend with other users.

Moving beyond the high-level stuff, @vahi, I wanted to let you know that the `flux_local_submit_attributes.sh` mimics the Slurm equivalent. As a result, it supports all the same CERequirements variables as Slurm, plus the following extra variables:
* `EXCLUSIVE`: if defined and set to "yes", the `--exclusive` flag will be passed to `flux batch` enabling exclusive node allocations.
* `GPUS`: specifies the number of GPUs per node. Only used if `NODES` is provided or a number of nodes can be derived from `CORES` and `PROCS`.

There are some differences in how `NODES`, `CORES`, and `PROCS` are processed compared to the Slurm script. These differences are necessary due to differences between Slurm and Flux, although the logic is the same as what I have in `flux_submit.sh` from my HTCondor PR. I'll also provide some extra details in #2143 alongside the mapping table you requested yesterday.

@deelman and @taufer, I'm pinging you on this PR too, just to keep you both in the loop.