### PR TITLE
Bugfix: removes incorrect use of the 'local' keyword in flux_local_submit_attributes.sh

### DIFF
--- a/doc/sphinx/user-guide/deployment-scenarios.rst
+++ b/doc/sphinx/user-guide/deployment-scenarios.rst
@@ -608,36 +608,36 @@ The tables below indicate the mapping of Pegasus profile keys to various schedul
 
         .. table:: Mapping to Flux Directives
 
-            +-------------------------+------------------------+------------------+
-            | Profile Key             | Key in                 | Flux Parameter   |
-            |                         | +remote_cerequirements |                  |
-            +-------------------------+------------------------+------------------+
-            | pegasus.cores           | CORES                  | --nslots,        |
-            |                         |                        | --nodes,         |
-            |                         |                        | and/or           |
-            |                         |                        | --cores-per-slot |
-            +-------------------------+------------------------+------------------+
-            | pegasus.gpus            | GPUS                   | --gpus-per-slot  |
-            +-------------------------+------------------------+------------------+
-            | pegasus.nodes           | NODES                  | --nodes          |
-            +-------------------------+------------------------+------------------+
-            | pegasus.ppn             | PROCS                  | --nslots,        |
-            |                         |                        | --nodes,         |
-            |                         |                        | and/or           |
-            |                         |                        | --cores-per-slot |
-            +-------------------------+------------------------+------------------+
-            | pegasus.runtime         | WALLTIME               | --time-limit     |
-            +-------------------------+------------------------+------------------+
-            | pegasus.memory          | PER_PROCESS_MEMORY     | Not supported    |
-            +-------------------------+------------------------+------------------+
-            | pegasus.project         | PROJECT                | --bank           |
-            +-------------------------+------------------------+------------------+
-            | pegasus.queue           | QUEUE                  | --queue          |
-            +-------------------------+------------------------+------------------+
-            | globus.totalmemory      | TOTAL_MEMORY           | Not supported    |
-            +-------------------------+------------------------+------------------+
-            | pegasus.glite.arguments | EXTRA_ARGUMENTS        | Not supported    |
-            +-------------------------+------------------------+------------------+
+            +-------------------------+------------------------+----------------------+
+            | Profile Key             | Key in                 | Flux Parameter       |
+            |                         | +remote_cerequirements |                      |
+            +-------------------------+------------------------+----------------------+
+            | pegasus.cores           | CORES                  | --nslots,            |
+            |                         |                        | --nodes,             |
+            |                         |                        | and/or               |
+            |                         |                        | --cores-per-slot     |
+            +-------------------------+------------------------+----------------------+
+            | pegasus.gpus            | GPUS                   | --gpus-per-slot      |
+            +-------------------------+------------------------+----------------------+
+            | pegasus.nodes           | NODES                  | --nodes              |
+            +-------------------------+------------------------+----------------------+
+            | pegasus.ppn             | PROCS                  | --nslots,            |
+            |                         |                        | --nodes,             |
+            |                         |                        | and/or               |
+            |                         |                        | --cores-per-slot     |
+            +-------------------------+------------------------+----------------------+
+            | pegasus.runtime         | WALLTIME               | --time-limit         |
+            +-------------------------+------------------------+----------------------+
+            | pegasus.memory          | PER_PROCESS_MEMORY     | Not supported        |
+            +-------------------------+------------------------+----------------------+
+            | pegasus.project         | PROJECT                | --bank               |
+            +-------------------------+------------------------+----------------------+
+            | pegasus.queue           | QUEUE                  | --queue              |
+            +-------------------------+------------------------+----------------------+
+            | globus.totalmemory      | TOTAL_MEMORY           | Not supported        |
+            +-------------------------+------------------------+----------------------+
+            | pegasus.glite.arguments | EXTRA_ARGUMENTS        | Prefixed by "#FLUX:" |
+            +-------------------------+------------------------+----------------------+
 
 Specifying a remote directory for the job
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/share/pegasus/htcondor/glite/flux_local_submit_attributes.sh
+++ b/share/pegasus/htcondor/glite/flux_local_submit_attributes.sh
@@ -43,10 +43,10 @@ fi
 #   * PROCS -> bls_opt_smpgranularity
 #   * CORES -> bls_opt_mpinodes
 #   * GPUS -> bls_opt_gpunumber
-local __flux_nnodes=
-local __flux_nslots=
-local __flux_ncores_per_slot=
-local __flux_ngpus_per_slot=
+__flux_nnodes=
+__flux_nslots=
+__flux_ncores_per_slot=
+__flux_ngpus_per_slot=
 
 if [ -n "${NODES}" ] || ([ -n "${PROCS}" ] && [ -n "${CORES}" ]); then
     if [ -n "${NODES}" ]; then
@@ -54,7 +54,7 @@ if [ -n "${NODES}" ] || ([ -n "${PROCS}" ] && [ -n "${CORES}" ]); then
     else
         __flux_nnodes=$(( (CORES + PROCS - 1) / PROCS ))
     fi
-    local __cores_per_slot_from_CORES=
+    __cores_per_slot_from_CORES=
     if [ -n "${CORES}" ]; then
         __cores_per_slot_from_CORES=$(( (CORES + __flux_nnodes - 1) / __flux_nnodes ))
     fi


### PR DESCRIPTION
@vahi in testing the HTCondor changes requested by Jaime, I realized that there was a bug in `flux_local_submit_attributes.sh` (from #2144). I was using Bash's `local` keyword outside of a function, which is supposed to trigger an error. I'm not sure why I wasn't getting errors yesterday, but this PR fixes them.