### PR TITLE
fix: Python <3.11 UTC import and deploy version glob

### DIFF
--- a/packages/pegasus-worker/src/Pegasus/cli/pegasus-integrity.py
+++ b/packages/pegasus-worker/src/Pegasus/cli/pegasus-integrity.py
@@ -14,7 +14,7 @@ import os
 import pprint
 import sys
 import time
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from shlex import quote
 
 # PEGASUS_PYTHONPATH is set by the pegasus-python-wrapper script
@@ -281,7 +281,7 @@ def iso8601(ts):
     :return: ISO 8601 formatted string (e.g. ``"2024-01-15T12:34:56"``)
     :rtype: str
     """
-    dt = datetime.fromtimestamp(ts, UTC)
+    dt = datetime.fromtimestamp(ts, timezone.utc)
     return dt.isoformat()
 
 

--- a/release-tools/deploy
+++ b/release-tools/deploy
@@ -23,7 +23,7 @@ tar xzf pegasus-doc-*.tar.gz -C docs
 
 DOWNLOADS=pegasus/$VERSION
 mkdir -p $DOWNLOADS
-mv pegasus-5*.tar.gz $DOWNLOADS/
+mv pegasus-$VERSION.tar.gz $DOWNLOADS/
 mv pegasus-binary-*.tar.gz $DOWNLOADS/
 mv pegasus-worker-*.tar.gz $DOWNLOADS/
 mv pegasus-doc-*.tar.gz $DOWNLOADS/


### PR DESCRIPTION
## Summary

Two fixes that unblock master CI (currently red).

### 1. `pegasus-integrity.py` — Python <3.11 compatibility (`852fa2f09`)
`from datetime import UTC` was introduced by commit `939d3c686`, but `datetime.UTC` only exists in Python 3.11+. pegasus-worker supports Python 3.6+, so the import raised `ImportError` on the CI runners, failing 7 tests in `test_pegasus_integrity.py` (all 6 worker jobs red). Switched to `datetime.timezone.utc`.

### 2. `release-tools/deploy` — version-agnostic artifact glob (`20586bc4d`)
The deploy step globbed `pegasus-5*.tar.gz` to move the main source tarball, which broke after the version bump to `6.0.0-dev.0` (artifact is now `pegasus-6.0.0-dev.0.tar.gz`). Uses `$VERSION` so it stays correct across major bumps.

## Testing
- Unit pipeline on this branch (4707): **all 16 test jobs pass**, including the previously-failing worker jobs across x86_64/arm64 and Python 3.6/3.7.
- Deploy glob fix verified by inspection against the real `6.0.0-dev.0` artifact names (not re-run on the branch to avoid an unintended production deploy).