### PR TITLE
fix: pegasus-status crash on freshly-started workflow (GH #2205)

### DIFF
--- a/packages/pegasus-common/src/Pegasus/client/status.py
+++ b/packages/pegasus-common/src/Pegasus/client/status.py
@@ -674,7 +674,7 @@ class Status:
             for index, each_dag in enumerate(self.dag_tree_struct):
                 if not index:
                     dag_dict = values["dags"]["root"]
-                    state = dag_dict[self.K_DAGSTATE]
+                    state = dag_dict[self.K_DAGSTATE] or self.DAG_OK
                     name = values["dags"]["root"]["dagname"]
                 elif each_dag[0] == "totals":
                     dag_dict = values["totals"]
@@ -683,7 +683,7 @@ class Status:
                 else:
                     dag = Path(each_dag[0]).stem
                     dag_dict = values["dags"][dag]
-                    state = dag_dict[self.K_DAGSTATE]
+                    state = dag_dict[self.K_DAGSTATE] or self.DAG_OK
                     name = each_dag[1]
 
                 print(
@@ -692,7 +692,7 @@ class Status:
 
         dag_state_counts = {"Running": 0, "Success": 0, "Failure": 0}
         for each_dag in values["dags"]:
-            dag_state_counts[values["dags"][each_dag]["state"]] += 1
+            dag_state_counts[values["dags"][each_dag]["state"] or self.DAG_OK] += 1
 
         done = {False: "", True: "Success:{} ".format(dag_state_counts["Success"])}
         fail = {False: "", True: "Failure:{} ".format(dag_state_counts["Failure"])}

--- a/packages/pegasus-common/test/status_sample_files/sample_started/sample_started.dag.dagman.out
+++ b/packages/pegasus-common/test/status_sample_files/sample_started/sample_started.dag.dagman.out
@@ -1,0 +1,8 @@
+08/04/22 12:07:24 ******************************************************
+08/04/22 12:07:24 ** condor_scheduniv_exec.3793.0 (CONDOR_DAGMAN) STARTING UP
+08/04/22 12:07:24 ** /usr/bin/condor_dagman
+08/04/22 12:07:24 ** $CondorVersion: 9.10.0 2022-07-14 BuildID: 596547 PackageID: 9.10.0-1 $
+08/04/22 12:07:24 ** PID = 2534233
+08/04/22 12:07:24 ******************************************************
+08/04/22 12:07:24 Using config source: /etc/condor/condor_config
+08/04/22 12:07:24 Setting up DAG: just starting, no node status reported yet

--- a/packages/pegasus-common/test/test_status.py
+++ b/packages/pegasus-common/test/test_status.py
@@ -529,6 +529,29 @@ def test_show_dag_progress_long(
     Pegasus.client.status.Status.get_q_values.assert_called_once_with()
 
 
+def test_show_dag_progress_just_started(mocker, capsys, status):
+    # dagman.out exists but DAGMan has not yet logged a node-status table,
+    # so the DAG state is still None. It must render as Running, not crash
+    # with "unsupported format string passed to NoneType.__format__".
+    expected_output = dedent(
+        """
+        (No matching jobs found in Condor Q)
+
+        UNREADY READY  PRE  IN_Q  POST  DONE  FAIL %DONE  STATE  DAGNAME
+           0      0     0    0     0     0     0    0.0  Running sample_started.dag
+        Summary: 1 DAG total (Running:1)
+        """
+    )
+    mocker.patch("Pegasus.client.status.Status.get_braindump")
+    mocker.patch("Pegasus.client.status.Status.get_q_values", return_value=None)
+    status.root_wf_name = "sample_started"
+    submit_dir = os.path.join(directory, "status_sample_files/sample_started")
+    status.fetch_status(submit_dir, long=True)
+    captured = capsys.readouterr()
+    assert captured.out == expected_output
+    Pegasus.client.status.Status.get_q_values.assert_called_once_with()
+
+
 def test_get_progress_no_dagmans_found(mocker, status):
     submit_dir = "invalid/submit/dir"
     assert status.get_progress(submit_dir) is None


### PR DESCRIPTION
## Summary

`pegasus-status` could crash with `TypeError: unsupported format string passed to NoneType.__format__` when run right after a workflow started.

Fixes #2205.

## Root cause

At workflow start the `*.dag.dagman.out` file already exists, but DAGMan has not yet written its node-status table. `parse_dagman_file()` therefore never matches a progress/exit line, so the per-DAG `state` (`K_DAGSTATE`) stays at its initialized `None`. `show_job_progress()` then formats that `None` with an alignment spec (`{state:^8}`) → `TypeError`. A latent `KeyError(None)` also lurks in the summary counter for the same window.

## Fix

Guard at the display layer — an unreported state renders as `Running` (`state or self.DAG_OK`), applied both to the per-DAG row and the summary counter. The `None` is kept in the data model (it honestly means "not yet reported"); only the display falls back. Completed workflows are unaffected: their dagman.out always yields a parsed `Success`/`Failure` that overwrites the default before display.

## Testing

- New sample `status_sample_files/sample_started/` (startup-only dagman.out, no progress line).
- New test `test_show_dag_progress_just_started` exercises `-l`/long mode and asserts it renders `Running` instead of crashing.
- Full `test_status.py` passes (33 tests).