### PR TITLE
fix: canonicalize cleanup remove URLs to avoid rm of <dir>/. (#1185)

### DIFF
--- a/src/edu/isi/pegasus/planner/refiner/RemoveDirectory.java
+++ b/src/edu/isi/pegasus/planner/refiner/RemoveDirectory.java
@@ -355,6 +355,28 @@ public class RemoveDirectory extends Engine {
     }
 
     /**
+     * Canonicalizes a url that is passed to the transfer tool for a remove operation, by
+     * normalizing its path component. This collapses redundant elements such as a trailing "/."
+     * (which results when the planner is invoked with --relative-submit-dir . ) that otherwise
+     * makes the cleanup job fail with rm: "." and ".." may not be removed (GH-1185).
+     *
+     * <p>The normalization is purely lexical (it does not resolve symbolic links), so the path is
+     * not altered beyond removing the redundant elements.
+     *
+     * @param url the url to canonicalize.
+     * @return the canonicalized url.
+     */
+    protected static String canonicalizeURL(String url) {
+        PegasusURL pegasusURL = new PegasusURL(url);
+        String path = pegasusURL.getPath();
+        if (path == null || path.isEmpty()) {
+            return url;
+        }
+        String normalized = new File(path).toPath().normalize().toString();
+        return pegasusURL.getURLPrefix() + normalized;
+    }
+
+    /**
      * It creates a remove directory job that creates a directory on the remote pool using the perl
      * executable that Gaurang wrote. It access mkdir underneath. It gets the name of the random
      * directory from the Pool handle.
@@ -520,6 +542,12 @@ public class RemoveDirectory extends Engine {
 
             int fileNum = 1;
             for (String file : urls) {
+
+                // GH-1185 canonicalize the path before passing it to the transfer
+                // tool. Otherwise a url such as <dir>/. (which happens when planning
+                // with --relative-submit-dir . ) makes the cleanup job run
+                // rm -rf <dir>/. that fails with rm: "." and ".." may not be removed
+                file = canonicalizeURL(file);
 
                 if (fileNum > 1) {
                     writer.write("  ,\n");

--- a/test/junit/edu/isi/pegasus/planner/refiner/RemoveDirectoryTest.java
+++ b/test/junit/edu/isi/pegasus/planner/refiner/RemoveDirectoryTest.java
@@ -70,4 +70,29 @@ public class RemoveDirectoryTest {
         Method method = RemoveDirectory.class.getMethod("getCompleteTransformationName");
         assertThat((Object) method.getReturnType(), is((Object) String.class));
     }
+
+    @Test
+    public void testCanonicalizeURLCollapsesTrailingDot() {
+        // GH-1185 a trailing /. (from --relative-submit-dir . ) must be collapsed
+        assertThat(
+                RemoveDirectory.canonicalizeURL("file:///scratch/run0001/."),
+                is("file:///scratch/run0001"));
+        assertThat(
+                RemoveDirectory.canonicalizeURL("gsiftp://example.org/data/work/."),
+                is("gsiftp://example.org/data/work"));
+    }
+
+    @Test
+    public void testCanonicalizeURLLeavesPlainPathUnchanged() {
+        assertThat(
+                RemoveDirectory.canonicalizeURL("file:///scratch/run0001"),
+                is("file:///scratch/run0001"));
+    }
+
+    @Test
+    public void testCanonicalizeURLCollapsesRedundantElements() {
+        assertThat(
+                RemoveDirectory.canonicalizeURL("file:///scratch/./run0001/"),
+                is("file:///scratch/run0001"));
+    }
 }


### PR DESCRIPTION
## Summary

Leaf cleanup jobs could fail at runtime with:

```
rm: "." and ".." may not be removed
```

when the relative (exec) directory resolved to `.` (e.g. planning with
`--relative-dir .`). The planner joins paths via `new File(dir, ".")`, which
leaves a trailing `/.` that `File.getPath()` / `getAbsolutePath()` do not
collapse, and that path was handed to `pegasus-transfer` verbatim as
`rm -rf <dir>/.`.

This canonicalizes the path component of each remove URL before it is written
to the cleanup job's `pegasus-transfer` input, collapsing redundant elements
(`/.`, `/./`, `//`). The normalization is purely lexical — it does **not**
resolve symbolic links — so the path is otherwise unchanged.

## Reproduction (before fix)

```
pegasus-plan --dir submit --relative-dir . \
    --sites condorpool --output-sites local --cleanup leaf workflow.yml
```

with a `local` site that has a `sharedScratch` directory produces:

```json
{ "type": "remove",
  "target": { "url": "file:///path/to/scratch/.", "recursive": "True" } }
```

→ cleanup job runs `rm -rf /path/to/scratch/.` and fails.

## Tests

Added unit tests in `RemoveDirectoryTest` covering `canonicalizeURL`:
trailing `/.`, embedded `/./`, plain paths (unchanged), and non-`file:` schemes
(`gsiftp://`). All pass.

Closes #1185
