### PR TITLE
fix: correct pegasus-rc-converter format help and add round-trip tests (GH-1650)

### DIFF
--- a/doc/sphinx/manpages/pegasus-rc-converter.rst
+++ b/doc/sphinx/manpages/pegasus-rc-converter.rst
@@ -24,18 +24,18 @@ Description
 ===========
 
 The **pegasus-rc-converter** program parses the replica catalogs in
-given input format (File, File, Database) and generates replica catalogs
-into given output format (File, File, Database).
+given input format (File, Regex, YAML) and generates replica catalogs
+into given output format (File, Regex, YAML).
 
 
 Options
 =======
 
 **-I**; **–iformat**
-    The input format for the files . Can be [File, YAML].
+    The input format for the files . Can be [File, Regex, YAML].
 
 **-O**; **–oformat**
-    The output format of the file. Can be [File, YAML].
+    The output format of the file. Can be [File, Regex, YAML].
 
 **-i**; **–input**
     Comma separated list of input files to convert. This option
@@ -75,5 +75,5 @@ Example
 
 ::
 
-   # File to file format conversion
-   $ pegasus-rc-converter -i cc.txt -I File -o rc.yml -v
+   # File (4.9 text) to YAML (5.0) format conversion
+   $ pegasus-rc-converter -i cc.txt -I File -o rc.yml -O YAML -v

--- a/src/edu/isi/pegasus/planner/client/RCConverter.java
+++ b/src/edu/isi/pegasus/planner/client/RCConverter.java
@@ -404,8 +404,8 @@ public class RCConverter extends Executable {
         text.append(
                 "\n"
                     + " pegasus-rc-converter - Parses the replica catalogs in given input format ("
-                    + " File ,File ,Database ) and generates replica catalog into given output"
-                    + " format ( File ,File ,Database )");
+                    + " File, Regex, YAML ) and generates replica catalog into given output format"
+                    + " ( File, Regex, YAML )");
         text.append("\n ");
         text.append(
                 "\n"
@@ -422,8 +422,13 @@ public class RCConverter extends Executable {
         text.append("\n Mandatory Options ");
         text.append("\n");
         text.append(
-                "\n -I |--iformat        the input format for the files . Can be [File, YAML] ");
-        text.append("\n -O |--oformat        the output format of the file. Can be [File, YAML] ");
+                "\n"
+                    + " -I |--iformat        the input format for the files . Can be [File, Regex,"
+                    + " YAML] ");
+        text.append(
+                "\n"
+                    + " -O |--oformat        the output format of the file. Can be [File, Regex,"
+                    + " YAML] ");
         text.append(
                 "\n"
                     + " -i |--input          comma separated list of input files to convert.This"
@@ -457,8 +462,8 @@ public class RCConverter extends Executable {
         text.append("\n");
         text.append("\n");
         text.append("\n Example Usage ");
-        text.append("\n File to file format conversion :- ");
-        text.append("  pegasus-rc-converter  -i cc.txt -I File -o rc.yml -v");
+        text.append("\n File (4.9 text) to YAML (5.0) format conversion :- ");
+        text.append("  pegasus-rc-converter  -i cc.txt -I File -o rc.yml -O YAML -v");
 
         System.out.println(text.toString());
     }

--- a/test/junit/edu/isi/pegasus/planner/client/RCConverterTest.java
+++ b/test/junit/edu/isi/pegasus/planner/client/RCConverterTest.java
@@ -14,19 +14,28 @@
 package edu.isi.pegasus.planner.client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
 
 import edu.isi.pegasus.common.logging.LogManager;
+import edu.isi.pegasus.common.logging.LogManagerFactory;
+import edu.isi.pegasus.planner.common.PegasusProperties;
 
 import gnu.getopt.LongOpt;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junitpioneer.jupiter.ClearSystemProperty;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
 import java.util.MissingResourceException;
 
 /**
@@ -98,6 +107,128 @@ public class RCConverterTest {
         assertThat(
                 exception.getMessage(),
                 is("Input files not specified. Specify the --input option"));
+    }
+
+    @Test
+    public void testConvertsBetween49FileAnd50YamlFormats(@TempDir Path tempDir) throws Exception {
+        // GH-1650: pegasus-rc-converter must support both the 4.9 (File) textual
+        // format and the 5.0 (YAML) format, in either direction.
+        Path input = tempDir.resolve("rc.txt");
+        Files.write(
+                input,
+                ("f.a file:///tmp/f.a site=\"local\"\n"
+                                + "f.b file:///tmp/f.b site=\"local\""
+                                + " checksum.type=\"sha256\" checksum.value=\"abc\"\n")
+                        .getBytes(StandardCharsets.UTF_8));
+
+        // 4.9 File -> 5.0 YAML
+        Path yaml = tempDir.resolve("rc.yml");
+        runConversion(input.toString(), "File", yaml.toString(), "YAML");
+
+        String yamlContent = new String(Files.readAllBytes(yaml), StandardCharsets.UTF_8);
+        assertThat(yamlContent, containsString("pegasus: \"5.0\""));
+        assertThat(yamlContent, containsString("lfn: \"f.a\""));
+        assertThat(yamlContent, containsString("pfn: \"file:///tmp/f.a\""));
+        assertThat(yamlContent, containsString("sha256: \"abc\""));
+
+        // 5.0 YAML -> 4.9 File
+        Path back = tempDir.resolve("back.txt");
+        runConversion(yaml.toString(), "YAML", back.toString(), "File");
+
+        String backContent = new String(Files.readAllBytes(back), StandardCharsets.UTF_8);
+        assertThat(backContent, containsString("f.a"));
+        assertThat(backContent, containsString("file:///tmp/f.a"));
+        assertThat(backContent, containsString("f.b"));
+        assertThat(backContent, containsString("file:///tmp/f.b"));
+    }
+
+    @Test
+    public void testConvertsRegexEntryFromYamlToFile(@TempDir Path tempDir) throws Exception {
+        // GH-1650: a regex replica entry in the 5.0 YAML format must survive
+        // conversion to the 4.9 File format as a regex="true" attribute.
+        Path yaml = tempDir.resolve("rc.yml");
+        Files.write(
+                yaml,
+                ("pegasus: \"5.0\"\n"
+                                + "replicas:\n"
+                                + "  - lfn: \"f.a\"\n"
+                                + "    pfns:\n"
+                                + "      - pfn: \"file:///tmp/f.a\"\n"
+                                + "        site: \"local\"\n"
+                                + "  - lfn: \"file_(.*).txt\"\n"
+                                + "    pfns:\n"
+                                + "      - pfn: \"file:///data/[1]\"\n"
+                                + "        site: \"local\"\n"
+                                + "    regex: true\n")
+                        .getBytes(StandardCharsets.UTF_8));
+
+        Path out = tempDir.resolve("rc.txt");
+        runConversion(yaml.toString(), "YAML", out.toString(), "File");
+
+        String content = new String(Files.readAllBytes(out), StandardCharsets.UTF_8);
+        // the plain entry is preserved
+        assertThat(content, containsString("f.a"));
+        assertThat(content, containsString("file:///tmp/f.a"));
+        // the regex entry keeps its pattern and is flagged as a regex
+        assertThat(content, containsString("file_(.*).txt"));
+        assertThat(content, containsString("file:///data/[1]"));
+        assertThat(content, containsString("regex=\"true\""));
+
+        // reverse direction: 4.9 File -> 5.0 YAML. The regex LFN pattern, pfn and
+        // site survive the round trip. (The regex flag itself is not yet re-emitted
+        // by the YAML writer, so it is not asserted here.)
+        Path roundtrip = tempDir.resolve("roundtrip.yml");
+        runConversion(out.toString(), "File", roundtrip.toString(), "YAML");
+
+        String yamlContent = new String(Files.readAllBytes(roundtrip), StandardCharsets.UTF_8);
+        assertThat(yamlContent, containsString("pegasus: \"5.0\""));
+        assertThat(yamlContent, containsString("lfn: \"f.a\""));
+        assertThat(yamlContent, containsString("lfn: \"file_(.*).txt\""));
+        assertThat(yamlContent, containsString("pfn: \"file:///data/[1]\""));
+    }
+
+    /**
+     * Drives a single conversion through the converter's internal pipeline, bypassing the
+     * argv/getopt path (which calls System.exit) while still exercising the real load-and-convert
+     * logic.
+     */
+    private void runConversion(
+            String inputFile, String inputFormat, String outputFile, String outputFormat)
+            throws Exception {
+        RCConverter converter = new RCConverter();
+
+        PegasusProperties props = PegasusProperties.nonSingletonInstance();
+        props.setProperty(
+                "pegasus.home.schemadir", new File("share/pegasus/schema").getAbsolutePath());
+
+        // The shared singleton logger's formatter keeps an event stack that is
+        // only populated by logEventStart; start (and later complete) an event so
+        // the conversion's log calls work regardless of test execution order.
+        LogManager logger = LogManagerFactory.loadSingletonInstance(props);
+        logger.logEventStart("event.pegasus.pegasus-rc-converter", "pegasus.version", "test");
+
+        ReflectionTestUtils.setField(converter, "mProps", props);
+        ReflectionTestUtils.setField(converter, "mLogger", logger);
+        ReflectionTestUtils.setField(
+                converter, "mInputFiles", Collections.singletonList(inputFile));
+        ReflectionTestUtils.setField(converter, "mInputFormat", inputFormat);
+        ReflectionTestUtils.setField(converter, "mOutputFile", outputFile);
+        ReflectionTestUtils.setField(converter, "mOutputFormat", outputFormat);
+        ReflectionTestUtils.setField(converter, "mDoVariableExpansion", false);
+
+        java.lang.reflect.Method method =
+                RCConverter.class.getDeclaredMethod("convertReplicaCatalogs");
+        method.setAccessible(true);
+        try {
+            method.invoke(converter);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            if (e.getCause() instanceof Exception) {
+                throw (Exception) e.getCause();
+            }
+            throw e;
+        } finally {
+            logger.logEventCompletion();
+        }
     }
 
     private Object getStaticField(String name) throws Exception {


### PR DESCRIPTION
## Summary

Closes #1650.

`pegasus-rc-converter` already converts the replica catalog between the 4.9 (`File`) textual format and the 5.0 (`YAML`) format in either direction. This PR fixes the stale CLI/manpage help and adds end-to-end test coverage to lock the behavior in.

## Changes

- **Help / docs:** `RCConverter --help` and `pegasus-rc-converter.rst` advertised the wrong, stale format list `"(File, File, Database)"` and omitted `Regex`/`YAML`. They now list the actual supported formats: `File, Regex, YAML`. Also fixed the example labelled "File to file" that actually did File→YAML.
- **Tests:** new `RCConverterTest` cases:
  - 4.9 `File` ↔ 5.0 `YAML` round-trip, including checksum metadata.
  - A regex entry converting 5.0 `YAML` → 4.9 `File` (`regex="true"`) and back to 5.0 `YAML`.

## Verification

- Ran the converter on real inputs in both directions (File↔YAML, incl. checksums; YAML regex → File).
- `RCConverterTest` — all 7 tests pass; google-java-format clean.

## Follow-up (not in this PR)

The YAML writer does not re-emit the `regex: true` flag, so a regex entry round-tripping through YAML loses its regex flag. The new test documents this and deliberately does not assert the flag on the reverse path.
