### PR TITLE
fix: clear error for invalid stageable transformation pfn (GH-1520)

### DIFF
--- a/src/edu/isi/pegasus/planner/refiner/InterPoolEngine.java
+++ b/src/edu/isi/pegasus/planner/refiner/InterPoolEngine.java
@@ -478,6 +478,7 @@ public class InterPoolEngine extends Engine implements Refiner {
             // the physical transformation points to
             // guc or the user specified transfer mechanism
             // accessible url
+            validateStageablePFN(entry);
             fTx.addSource(entry.getResourceId(), entry.getPhysicalTransformation());
 
             // PM-1386 set bypass for executable if set
@@ -499,6 +500,29 @@ public class InterPoolEngine extends Engine implements Refiner {
         }
 
         return fTx;
+    }
+
+    /**
+     * Validates that the physical transformation (pfn) for a stageable executable is a location it
+     * can actually be staged from. The pfn must contain a directory component (a path separator),
+     * so that the planner can later derive the source directory of the executable. A bare filename
+     * such as "script.sh" (instead of an absolute path or URL) is invalid and would otherwise
+     * trigger a cryptic StringIndexOutOfBoundsException later during staging.
+     *
+     * @param entry the transformation catalog entry whose pfn is to be validated
+     * @throws RuntimeException if the pfn is invalid
+     */
+    void validateStageablePFN(TransformationCatalogEntry entry) {
+        String pfn = entry.getPhysicalTransformation();
+        if (pfn == null || !pfn.contains(File.separator)) {
+            throw new RuntimeException(
+                    "Transformation "
+                            + entry.getLogicalTransformation()
+                            + " has invalid pfn: '"
+                            + pfn
+                            + "'. The pfn for a stageable executable must be an absolute path or a"
+                            + " URL.");
+        }
     }
 
     /**
@@ -620,6 +644,7 @@ public class InterPoolEngine extends Engine implements Refiner {
                         // the physical transformation points to
                         // guc or the user specified transfer mechanism
                         // accessible url
+                        validateStageablePFN(tcEntry);
                         fTx.addSource(tcEntry.getResourceId(), tcEntry.getPhysicalTransformation());
 
                         // PM-1386 set bypass for executable if set

--- a/test/junit/edu/isi/pegasus/planner/refiner/InterPoolEngineTest.java
+++ b/test/junit/edu/isi/pegasus/planner/refiner/InterPoolEngineTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import edu.isi.pegasus.common.logging.LogManager;
+import edu.isi.pegasus.planner.catalog.transformation.TransformationCatalogEntry;
 import edu.isi.pegasus.planner.classes.ADag;
 import edu.isi.pegasus.planner.classes.Job;
 import edu.isi.pegasus.planner.classes.PegasusBag;
@@ -179,6 +180,34 @@ public class InterPoolEngineTest {
         assertThat(engine.incorporateHint(j, Selector.EXECUTION_SITE_KEY), is(true));
         // selector profile is preferred
         assertThat(j.getSiteHandle(), is(site));
+        mLogger.logEventCompletion();
+    }
+
+    @Test
+    public void validateStageablePFNRejectsBareFilename() {
+        mLogger.logEventStart(
+                "test.refiner.interpoolengine", "set", Integer.toString(mTestNumber++));
+        InterPoolEngine engine = new InterPoolEngine(new ADag(), mBag);
+        TransformationCatalogEntry entry = new TransformationCatalogEntry(null, "script.sh", null);
+        entry.setPhysicalTransformation("script.sh");
+        RuntimeException e =
+                assertThrows(RuntimeException.class, () -> engine.validateStageablePFN(entry));
+        assertThat(
+                e.getMessage(),
+                is(
+                        "Transformation script.sh has invalid pfn: 'script.sh'. The pfn for a"
+                                + " stageable executable must be an absolute path or a URL."));
+        mLogger.logEventCompletion();
+    }
+
+    @Test
+    public void validateStageablePFNAcceptsAbsolutePath() {
+        mLogger.logEventStart(
+                "test.refiner.interpoolengine", "set", Integer.toString(mTestNumber++));
+        InterPoolEngine engine = new InterPoolEngine(new ADag(), mBag);
+        TransformationCatalogEntry entry = new TransformationCatalogEntry(null, "script.sh", null);
+        entry.setPhysicalTransformation("/path/to/script.sh");
+        engine.validateStageablePFN(entry);
         mLogger.logEventCompletion();
     }
 }


### PR DESCRIPTION
## Problem

Fixes #1520.

A transformation catalog entry with a bare-filename pfn — e.g. `pfn "script.sh"` instead of an absolute path or URL like `$(pwd)/script.sh` — crashed the planner deep in staging with a cryptic error:

```
java.lang.StringIndexOutOfBoundsException: String index out of range: -1
```

The crash originates in `StageIn`, which derives the source directory of a staged executable via `pfn.substring(0, pfn.lastIndexOf(File.separator))`. When the pfn has no path separator, `lastIndexOf` returns `-1` and `substring(0, -1)` throws.

## Fix

Validate the pfn of a **stageable** executable in `InterPoolEngine`, at the two points where a transformation's pfn is turned into a transfer source. This is the right altitude: the transformation name is still available here (it isn't in `StageIn`), so we can fail fast with a clear, user-facing message:

```
Transformation script.sh has invalid pfn: 'script.sh'. The pfn for a stageable executable must be an absolute path or a URL.
```

The shared `validateStageablePFN` helper avoids duplicating the check across the main- and dependent-executable staging paths.

## Tests

Added two JUnit cases to `InterPoolEngineTest`:
- `validateStageablePFNRejectsBareFilename` — asserts the new error message
- `validateStageablePFNAcceptsAbsolutePath` — a valid pfn passes

Full `InterPoolEngineTest` runs 8/8 passing locally.