### PR TITLE
chore: deprecated code cleanup (f-strings, stdlib, test harness fix)

### DIFF
--- a/packages/pegasus-api/src/Pegasus/api/_utils.py
+++ b/packages/pegasus-api/src/Pegasus/api/_utils.py
@@ -43,7 +43,7 @@ def _get_class_enum_member_str(_cls, _type):
                 enums.append(name)
 
     enums.sort()
-    return _cls.__name__ + ".<{members}>".format(members=" | ".join(enums))
+    return _cls.__name__ + f".<{' | '.join(enums)}>"
 
 
 def _get_enum_str(enum_cls):
@@ -70,9 +70,7 @@ def _get_enum_str(enum_cls):
             f"invalid enum_cls: {enum_cls}; enum_cls must be a subclass of Enum"
         )
 
-    return enum_cls.__name__ + ".<{members}>".format(
-        members=" | ".join(sorted(enum_cls._member_names_))
-    )
+    return enum_cls.__name__ + f".<{' | '.join(sorted(enum_cls._member_names_))}>"
 
 
 def _chained(f):

--- a/packages/pegasus-api/src/Pegasus/api/site_catalog.py
+++ b/packages/pegasus-api/src/Pegasus/api/site_catalog.py
@@ -465,9 +465,7 @@ class Site(ProfileMixin):
         """
         if not isinstance(ns, Namespace):
             raise TypeError(
-                "invalid ns: {ns}; ns should be one of {enum_str}".format(
-                    ns=ns, enum_str=", ".join(n.value for n in Namespace)
-                )
+                f"invalid ns: {ns}; ns should be one of {', '.join(n.value for n in Namespace)}"
             )
 
         if name not in self.tags:

--- a/packages/pegasus-api/test/api/test_site_catalog.py
+++ b/packages/pegasus-api/test/api/test_site_catalog.py
@@ -70,7 +70,7 @@ class TestDirectory:
         with pytest.raises(ValueError) as e:
             Directory(Directory.LOCAL_SCRATCH, Path("dir"))
 
-        assert "invalid path: {}".format(Path("dir")) in str(e)
+        assert f"invalid path: {Path('dir')}" in str(e)
 
     def test_add_valid_file_server(self):
         d = Directory(Directory.LOCAL_SCRATCH, "/path")

--- a/packages/pegasus-api/test/api/test_workflow.py
+++ b/packages/pegasus-api/test/api/test_workflow.py
@@ -170,7 +170,7 @@ class TestAbstractJob:
         with pytest.raises(DuplicateError) as e:
             job.add_inputs(File("a"))
 
-        assert "file: {file}".format(file=File("a")) in str(e)
+        assert f"file: {File('a')}" in str(e)
 
     def test_add_invalid_input(self):
         job = AbstractJob()
@@ -204,7 +204,7 @@ class TestAbstractJob:
         with pytest.raises(DuplicateError) as e:
             job.add_outputs(File("a"))
 
-        assert "file: {file}".format(file=File("a")) in str(e)
+        assert f"file: {File('a')}" in str(e)
 
     def test_add_invalid_output(self):
         job = AbstractJob()
@@ -221,7 +221,7 @@ class TestAbstractJob:
         with pytest.raises(DuplicateError) as e:
             job.add_inputs(File("b"))
 
-        assert "file: {file}".format(file=File("b")) in str(e)
+        assert f"file: {File('b')}" in str(e)
 
     def test_add_checkpoint(self):
         job = AbstractJob()
@@ -244,7 +244,7 @@ class TestAbstractJob:
         with pytest.raises(DuplicateError) as e:
             job.add_checkpoint(File("abc"))
 
-        assert "file: {file}".format(file=File("abc")) in str(e)
+        assert f"file: {File('abc')}" in str(e)
 
     def test_add_args(self):
         job = AbstractJob()
@@ -280,7 +280,7 @@ class TestAbstractJob:
         with pytest.raises(DuplicateError) as e:
             job.set_stdin(File("a"))
 
-        assert "file: {file}".format(file=File("a")) in str(e)
+        assert f"file: {File('a')}" in str(e)
 
     def test_set_invalid_stdin(self):
         job = AbstractJob()
@@ -315,7 +315,7 @@ class TestAbstractJob:
         with pytest.raises(DuplicateError) as e:
             job.set_stdout(File("a"))
 
-        assert "file: {file}".format(file=File("a")) in str(e)
+        assert f"file: {File('a')}" in str(e)
 
     def test_set_invalid_stdout(self):
         job = AbstractJob()

--- a/packages/pegasus-common/src/Pegasus/client/_client.py
+++ b/packages/pegasus-common/src/Pegasus/client/_client.py
@@ -640,17 +640,13 @@ class Client:
                 )
 
                 if stats:
-                    unready = blue(
-                        "Unready: {}".format(stats["dags"]["root"]["unready"])
-                    )
+                    unready = blue(f"Unready: {stats['dags']['root']['unready']}")
                     completed = green(
-                        "Completed: {}".format(stats["dags"]["root"]["succeeded"])
+                        f"Completed: {stats['dags']['root']['succeeded']}"
                     )
-                    queued = yellow("Queued: {}".format(stats["dags"]["root"]["ready"]))
-                    running = cyan(
-                        "Running: {}".format(stats["dags"]["root"]["queued"])
-                    )
-                    fail = red("Failed: {}".format(stats["dags"]["root"]["failed"]))
+                    queued = yellow(f"Queued: {stats['dags']['root']['ready']}")
+                    running = cyan(f"Running: {stats['dags']['root']['queued']}")
+                    fail = red(f"Failed: {stats['dags']['root']['failed']}")
 
                     stats_tuple = (
                         "("

--- a/packages/pegasus-common/src/Pegasus/client/status.py
+++ b/packages/pegasus-common/src/Pegasus/client/status.py
@@ -224,7 +224,7 @@ class Status:
     def show_debug_info(self) -> None:
         """Print the ``condor_q`` command that was used to query the HTCondor queue."""
         print("condor_q command used to retrieve jobs in Condor Q :")
-        print("{} {}".format(shutil.which("condor_q"), " ".join(self.q_cmd[1:])))
+        print(f"{shutil.which('condor_q')} {' '.join(self.q_cmd[1:])}")
 
     def get_q_values(self):
         """Internal method to retrieve Condor Q jobs."""
@@ -272,8 +272,8 @@ class Status:
         }
 
         if long:
-            idcol = "{:^8}".format("ID")
-            st = "{:^15}".format("SITE")
+            idcol = f"{'ID':^8}"
+            st = f"{'SITE':^15}"
         else:
             idcol = ""
             st = ""
@@ -291,11 +291,7 @@ class Status:
                 )
             )
 
-        print(
-            "\n{}{}{:5}{:^11}{:25}".format(
-                idcol, st, "STAT", "IN_STATE", "JOB"
-            ).rstrip()
-        )
+        print(f"\n{idcol}{st}{'STAT':5}{'IN_STATE':^11}{'JOB':25}".rstrip())
 
         job_counts = {
             self.JS_IDLE: 0,
@@ -329,8 +325,8 @@ class Status:
                 status = self.job_status_codes[job["JobStatus"]]
 
                 if long:
-                    jobid = "{:^8}".format(job["ClusterId"])
-                    site = "{:^15}".format(job["pegasus_site"])
+                    jobid = f"{job['ClusterId']:^8}"
+                    site = f"{job['pegasus_site']:^15}"
                 else:
                     jobid = ""
                     site = ""
@@ -339,14 +335,14 @@ class Status:
                 in_state = self.get_time(int(time.time() - job["EnteredCurrentStatus"]))
 
                 if job["pegasus_wf_xformation"] == "pegasus::dagman":
-                    job_name = "{} ({})".format(job["pegasus_wf_name"], job["Iwd"])
+                    job_name = f"{job['pegasus_wf_name']} ({job['Iwd']})"
                 else:
                     job_name = prefix + pointer + job["pegasus_wf_dag_job_id"]
 
                 print(f"{jobid}{site}{status:^5}{in_state:^11}{job_name:25}".rstrip())
                 if status == "Held":
                     screen_size = shutil.get_terminal_size().columns
-                    print("{}{}..".format(L, job["HoldReason"][: screen_size - 5]))
+                    print(f"{L}{job['HoldReason'][: screen_size - 5]}..")
 
                 if job["pegasus_wf_xformation"] == "condor::dagman":
                     extension = bar if pointer == t else space
@@ -361,10 +357,10 @@ class Status:
             for each_root_wf in root_wf_uuids:
                 print_q(each_root_wf)
 
-        idle = {False: "", True: "I:{} ".format(job_counts["Idle"])}
-        run = {False: "", True: "R:{} ".format(job_counts["Run"])}
-        held = {False: "", True: "H:{} ".format(job_counts["Held"])}
-        rem = {False: "", True: "X:{}".format(job_counts["Del"])}
+        idle = {False: "", True: f"I:{job_counts['Idle']} "}
+        run = {False: "", True: f"R:{job_counts['Run']} "}
+        held = {False: "", True: f"H:{job_counts['Held']} "}
+        rem = {False: "", True: f"X:{job_counts['Del']}"}
         total_jobs = len(condor_jobs)
         s = {False: "", True: "s"}
 
@@ -603,16 +599,16 @@ class Status:
         }
 
         column_names = {  # Long = False          ,     Long = True
-            "unready": ["{:^8}".format("UNREADY"), "{:^7}".format("UNREADY")],
-            "ready": ["{:^8}".format("READY"), "{:^7}".format("READY")],
-            "pre": ["{:^6}".format("PRE"), "{:^5}".format("PRE")],
-            "queued": ["{:^8}".format("QUEUED"), "{:^6}".format("IN_Q")],
-            "post": ["{:^8}".format("POST"), "{:^6}".format("POST")],
-            "completed": ["{:^9}".format("SUCCESS"), "{:^6}".format("DONE")],
-            "failed": ["{:^9}".format("FAILURE"), "{:^6}".format("FAIL")],
-            "percent_done": ["{:^8}".format("%DONE"), "{:^6}".format("%DONE")],
-            "state": ["", "{:^8}".format("STATE")],
-            "dagname": ["", "{:25}".format("DAGNAME")],
+            "unready": [f"{'UNREADY':^8}", f"{'UNREADY':^7}"],
+            "ready": [f"{'READY':^8}", f"{'READY':^7}"],
+            "pre": [f"{'PRE':^6}", f"{'PRE':^5}"],
+            "queued": [f"{'QUEUED':^8}", f"{'IN_Q':^6}"],
+            "post": [f"{'POST':^8}", f"{'POST':^6}"],
+            "completed": [f"{'SUCCESS':^9}", f"{'DONE':^6}"],
+            "failed": [f"{'FAILURE':^9}", f"{'FAIL':^6}"],
+            "percent_done": [f"{'%DONE':^8}", f"{'%DONE':^6}"],
+            "state": ["", f"{'STATE':^8}"],
+            "dagname": ["", f"{'DAGNAME':25}"],
         }
 
         if legend:
@@ -668,7 +664,7 @@ class Status:
 
         else:
             if self.is_hierarchical:
-                total_name = "TOTALS({} jobs)".format(values["totals"]["total"])
+                total_name = f"TOTALS({values['totals']['total']} jobs)"
                 self.dag_tree_struct.append(("totals", total_name))
 
             for index, each_dag in enumerate(self.dag_tree_struct):
@@ -694,9 +690,9 @@ class Status:
         for each_dag in values["dags"]:
             dag_state_counts[values["dags"][each_dag]["state"] or self.DAG_OK] += 1
 
-        done = {False: "", True: "Success:{} ".format(dag_state_counts["Success"])}
-        fail = {False: "", True: "Failure:{} ".format(dag_state_counts["Failure"])}
-        run = {False: "", True: "Running:{}".format(dag_state_counts["Running"])}
+        done = {False: "", True: f"Success:{dag_state_counts['Success']} "}
+        fail = {False: "", True: f"Failure:{dag_state_counts['Failure']} "}
+        run = {False: "", True: f"Running:{dag_state_counts['Running']}"}
         total_dags = len(values["dags"])
         s = {False: "", True: "s"}
 

--- a/packages/pegasus-python/src/Pegasus/cli/pegasus-cwl-converter.py
+++ b/packages/pegasus-python/src/Pegasus/cli/pegasus-cwl-converter.py
@@ -318,9 +318,7 @@ def build_pegasus_rc(wf_inputs: dict, cwl_wf: cwl.Workflow) -> ReplicaCatalog:
 
             try:
                 log.info(
-                    "Adding replica: site={}, lfn={}, pfn={}".format(
-                        "local", input_name, current_wf_inputs["path"]
-                    )
+                    f"Adding replica: site=local, lfn={input_name}, pfn={current_wf_inputs['path']}"
                 )
                 # TODO: what about other sites?
                 rc.add_replica("local", input_name, current_wf_inputs["path"])

--- a/packages/pegasus-python/src/Pegasus/cli/pegasus-run.py
+++ b/packages/pegasus-python/src/Pegasus/cli/pegasus-run.py
@@ -242,7 +242,11 @@ def pegasus_run(ctx, grid=False, json=False, verbose=0, submit_dir=None):
             halt_released = False
             if Path(config["dag"] + ".halt").exists():
                 click.echo("Found a previously halted workflow. Releasing it now.")
-                os.system("find . -name '*.dag.halt' -exec rm {} \\;")
+                for halt_file in Path(".").rglob("*.dag.halt"):
+                    try:
+                        halt_file.unlink()
+                    except OSError:
+                        pass
                 halt_released = True
 
             # After the switch from condor_submit_dag, we lost the check to see if

--- a/packages/pegasus-python/src/Pegasus/cli/pegasus-status.py
+++ b/packages/pegasus-python/src/Pegasus/cli/pegasus-status.py
@@ -137,7 +137,7 @@ def get_wf_status(ctx, long, jsonrv, watch, dirs, legend, noqueue, debug, submit
         continue_running = True
         while continue_running:
             try:
-                os.system("clear")
+                click.clear()
                 size = shutil.get_terminal_size().columns // 3
                 ctrlc = "{0:<{1}}".format("Press Ctrl+C to exit", size)
                 pid = "{0:^{1}}".format("(pid=" + str(os.getpid()) + ")", size)

--- a/packages/pegasus-python/src/Pegasus/cli/pegasus-status.py
+++ b/packages/pegasus-python/src/Pegasus/cli/pegasus-status.py
@@ -102,18 +102,14 @@ def get_wf_status(ctx, long, jsonrv, watch, dirs, legend, noqueue, debug, submit
             os.chdir(submit_dir)
         except PermissionError:
             click.secho(
-                "{}{} directory is not readable".format(
-                    click.style("Error: ", fg="red", bold=True), submit_dir
-                )
+                f"{click.style('Error: ', fg='red', bold=True)}{submit_dir} directory is not readable"
             )
             ctx.exit(1)
 
         braindb = slurp_braindb(submit_dir)
         if not braindb:
             click.secho(
-                "{}{} is not a valid workflow submit-directory".format(
-                    click.style("Error: ", fg="red", bold=True), submit_dir
-                )
+                f"{click.style('Error: ', fg='red', bold=True)}{submit_dir} is not a valid workflow submit-directory"
             )
             ctx.exit(1)
 
@@ -139,7 +135,7 @@ def get_wf_status(ctx, long, jsonrv, watch, dirs, legend, noqueue, debug, submit
             try:
                 click.clear()
                 size = shutil.get_terminal_size().columns // 3
-                ctrlc = "{0:<{1}}".format("Press Ctrl+C to exit", size)
+                ctrlc = f"{'Press Ctrl+C to exit':<{size}}"
                 pid = "{0:^{1}}".format("(pid=" + str(os.getpid()) + ")", size)
                 clock = "{0:>{1}}".format(
                     datetime.now().strftime("%a %b-%d-%Y %H:%M:%S"), size

--- a/packages/pegasus-python/src/Pegasus/db/admin/admin_loader.py
+++ b/packages/pegasus-python/src/Pegasus/db/admin/admin_loader.py
@@ -437,17 +437,11 @@ def all_workflows_db(
     f_err.close()
 
     print("\n\nSummary:")
-    print("  Verified/{}: {}/{}".format(msg[1], counts["success"], counts["total"]))
-    print("  Failed: {}/{}".format(counts["failed"], counts["total"]))
+    print(f"  Verified/{msg[1]}: {counts['success']}/{counts['total']}")
+    print(f"  Failed: {counts['failed']}/{counts['total']}")
+    print(f"  Unable to connect: {counts['unable_to_connect']}/{counts['total']}")
     print(
-        "  Unable to connect: {}/{}".format(
-            counts["unable_to_connect"], counts["total"]
-        )
-    )
-    print(
-        "  Unable to update (active workflows): {}/{}".format(
-            counts["running"], counts["total"]
-        )
+        f"  Unable to update (active workflows): {counts['running']}/{counts['total']}"
     )
     print("\nLog files:")
     print(f"  {file_prefix}.out (Succeeded operations)")

--- a/packages/pegasus-python/src/Pegasus/db/connection.py
+++ b/packages/pegasus-python/src/Pegasus/db/connection.py
@@ -482,7 +482,7 @@ def _get_jdbcrc_uri(props=None):
                 + database
             )
 
-        log.debug("Invalid JDBCRC driver: {}".format(rc_info["driver"]))
+        log.debug(f"Invalid JDBCRC driver: {rc_info['driver']}")
     return None
 
 

--- a/packages/pegasus-python/src/Pegasus/db/ensembles.py
+++ b/packages/pegasus-python/src/Pegasus/db/ensembles.py
@@ -380,15 +380,15 @@ class Ensembles:
         f.write(f"-Dpegasus.dashboard.output={self.dburi} \\\n")
 
         f.write("--conf pegasus.properties \\\n")
-        f.write("--site {} \\\n".format(",".join(sites)))
+        f.write(f"--site {','.join(sites)} \\\n")
         f.write(f"--output-site {output_site} \\\n")
 
         if staging_sites is not None and len(staging_sites) > 0:
             pairs = [f"{k}={v}" for k, v in staging_sites.items()]
-            f.write("--staging-site {} \\\n".format(",".join(pairs)))
+            f.write(f"--staging-site {','.join(pairs)} \\\n")
 
         if clustering is not None and len(clustering) > 0:
-            f.write("--cluster {} \\\n".format(",".join(clustering)))
+            f.write(f"--cluster {','.join(clustering)} \\\n")
 
         if force:
             f.write("--force \\\n")
@@ -396,7 +396,7 @@ class Ensembles:
         if cleanup is not None:
             f.write(f"--cleanup {cleanup} \\\n")
 
-        f.write("--dir {} \\\n".format(os.path.join(basedir, "submit")))
+        f.write(f"--dir {os.path.join(basedir, 'submit')} \\\n")
         f.write(f"--dax {os.path.join(bundledir, dax)} \\\n")
         f.write(f"--input-dir {bundledir} \n")
 

--- a/packages/pegasus-python/src/Pegasus/db/workflow/__init__.py
+++ b/packages/pegasus-python/src/Pegasus/db/workflow/__init__.py
@@ -48,11 +48,7 @@ class WorkflowBase:
             ):
                 continue
             try:
-                retval += "\n{}* {} : {}".format(
-                    spacer * self._indent,
-                    i,
-                    eval(f"self.{i}"),
-                )
+                retval += f"\n{spacer * self._indent}* {i} : {eval(f'self.{i}')}"
             except NotImplementedError as e:
                 retval += f"\n{spacer * self._indent}* {i} : WARNING: {e}"
         return retval

--- a/packages/pegasus-python/src/Pegasus/init.py
+++ b/packages/pegasus-python/src/Pegasus/init.py
@@ -182,9 +182,7 @@ def print_sites(sites_available):
 
     for k in sites_available:
         click.echo(
-            "{}) {}".format(
-                k, Sites.SitesAvailableDescription[sites_available[k]["member"]]
-            )
+            f"{k}) {Sites.SitesAvailableDescription[sites_available[k]['member']]}"
         )
 
     click.echo()
@@ -200,24 +198,18 @@ def print_workflows(workflows_available):
 
     for k in workflows_available:
         workflow = workflows_available[k]
-        click.echo(
-            "{}) {}/{}".format(k, workflow["organization"], workflow["repo_name"])
-        )
+        click.echo(f"{k}) {workflow['organization']}/{workflow['repo_name']}")
 
     click.echo()
     return
 
 
 def clone_workflow(wf_dir, workflow):
-    zip_url = "https://github.com/{}/{}/archive/HEAD.zip".format(
-        workflow["organization"], workflow["repo_name"]
-    )
+    zip_url = f"https://github.com/{workflow['organization']}/{workflow['repo_name']}/archive/HEAD.zip"
     dest = os.path.join(os.getcwd(), wf_dir, workflow["repo_name"])
 
     click.echo(
-        "Fetching workflow from https://github.com/{}/{}.git".format(
-            workflow["organization"], workflow["repo_name"]
-        )
+        f"Fetching workflow from https://github.com/{workflow['organization']}/{workflow['repo_name']}.git"
     )
 
     try:
@@ -271,11 +263,7 @@ def create_pegasus_properties(commands):
 
     props = Properties()
     props["pegasus.transfer.arguments"] = "-m 1"
-    commands.append(
-        'echo "{} = {}" > pegasus.properties'.format(
-            "pegasus.transfer.arguments", "-m 1"
-        )
-    )
+    commands.append('echo "pegasus.transfer.arguments = -m 1" > pegasus.properties')
 
     props.write()
 
@@ -333,9 +321,7 @@ def create_workflow(
     pegasushub_config = read_pegasushub_config(wf_dir, workflow)
 
     click.echo(
-        "Generating workflow based on {}/{}".format(
-            workflow["organization"], workflow["repo_name"]
-        )
+        f"Generating workflow based on {workflow['organization']}/{workflow['repo_name']}"
     )
     if queue_name:
         click.echo(f'This workflow will target queue "{queue_name}"')

--- a/packages/pegasus-python/src/Pegasus/monitoring/job.py
+++ b/packages/pegasus-python/src/Pegasus/monitoring/job.py
@@ -596,13 +596,7 @@ class Job:
 
                     my_record["hostname"] = self._host_id
                     logger.trace(
-                        "For job {} preferring {} {} over kickstart reported hostname {} {}".format(
-                            self._exec_job_id,
-                            my_record["hostname"],
-                            my_record["hostaddr"],
-                            ks_hostname,
-                            ks_hostaddr,
-                        )
+                        f"For job {self._exec_job_id} preferring {my_record['hostname']} {my_record['hostaddr']} over kickstart reported hostname {ks_hostname} {ks_hostaddr}"
                     )
 
             # PM-1109 encode signal information if it exists

--- a/packages/pegasus-python/src/Pegasus/monitoring/notifications.py
+++ b/packages/pegasus-python/src/Pegasus/monitoring/notifications.py
@@ -273,9 +273,8 @@ class Notifications:
             my_complete_env = os.environ.copy()
             my_complete_env.update(my_env)
             try:
-                my_notification = "{} - {}".format(
-                    my_env["PEGASUS_JOBID"],
-                    my_env["PEGASUS_EVENT"],
+                my_notification = (
+                    f"{my_env['PEGASUS_JOBID']} - {my_env['PEGASUS_EVENT']}"
                 )
             except KeyError:
                 logger.warning(
@@ -416,9 +415,8 @@ class Notifications:
         if len(self._pending_notifications) > 0:
             for my_action, my_env in self._pending_notifications:
                 try:
-                    my_notification = "{} - {}".format(
-                        my_env["PEGASUS_JOBID"],
-                        my_env["PEGASUS_EVENT"],
+                    my_notification = (
+                        f"{my_env['PEGASUS_JOBID']} - {my_env['PEGASUS_EVENT']}"
                     )
                 except KeyError:
                     logger.warning(

--- a/packages/pegasus-python/src/Pegasus/monitoring/workflow.py
+++ b/packages/pegasus-python/src/Pegasus/monitoring/workflow.py
@@ -2314,9 +2314,7 @@ class Workflow:
                             my_id = int(record["id"])
                         except Exception:
                             logger.warning(
-                                "task id looks invalid, cannot convert it to int: {} skipping to next".format(
-                                    record["id"]
-                                )
+                                f"task id looks invalid, cannot convert it to int: {record['id']} skipping to next"
                             )
                             continue
                         # Add to our list

--- a/packages/pegasus-python/src/Pegasus/netlogger/configobj.py
+++ b/packages/pegasus-python/src/Pegasus/netlogger/configobj.py
@@ -2022,22 +2022,22 @@ class ConfigObj(Section):
             val = self._decode_element(self._quote(this_entry))
         else:
             val = repr(this_entry)
-        return "{}{}{}{}{}".format(
-            indent_string,
-            self._decode_element(self._quote(entry, multiline=False)),
-            self._a_to_u(" = "),
-            val,
-            self._decode_element(comment),
+        return (
+            f"{indent_string}"
+            f"{self._decode_element(self._quote(entry, multiline=False))}"
+            f"{self._a_to_u(' = ')}"
+            f"{val}"
+            f"{self._decode_element(comment)}"
         )
 
     def _write_marker(self, indent_string, depth, entry, comment):
         """Write a section marker line"""
-        return "{}{}{}{}{}".format(
-            indent_string,
-            self._a_to_u("[" * depth),
-            self._quote(self._decode_element(entry), multiline=False),
-            self._a_to_u("]" * depth),
-            self._decode_element(comment),
+        return (
+            f"{indent_string}"
+            f"{self._a_to_u('[' * depth)}"
+            f"{self._quote(self._decode_element(entry), multiline=False)}"
+            f"{self._a_to_u(']' * depth)}"
+            f"{self._decode_element(comment)}"
         )
 
     def _handle_comment(self, comment):

--- a/packages/pegasus-python/src/Pegasus/netlogger/nllog.py
+++ b/packages/pegasus-python/src/Pegasus/netlogger/nllog.py
@@ -432,14 +432,10 @@ class Profiler(type):
     def __new__(cls, classname, bases, classdict):
         if os.getenv("NETLOGGER_ON", False) in ("off", "0", "no", "false", "", False):
             setLoggerClass(FakeBPLogger)
-            classdict["_log"] = _logger(
-                "{}.{}".format(classdict["__module__"], classname)
-            )
+            classdict["_log"] = _logger(f"{classdict['__module__']}.{classname}")
             return type.__new__(cls, classname, bases, classdict)
 
-        classdict["_log"] = log = _logger(
-            "{}.{}".format(classdict["__module__"], classname)
-        )
+        classdict["_log"] = log = _logger(f"{classdict['__module__']}.{classname}")
         log.set_meta(pid=os.getpid(), ppid=os.getppid(), gpid=os.getgid())
         keys = []
         if not classdict.get("profiler_skip_all", cls.profiler_skip_all):

--- a/packages/pegasus-python/src/Pegasus/netlogger/util.py
+++ b/packages/pegasus-python/src/Pegasus/netlogger/util.py
@@ -204,10 +204,10 @@ def parse_nvp(args):
 
 
 def tzstr():
-    return "{}{:02d}:{:02d}".format(
-        ("+", "-")[time.timezone > 0],
-        int(time.timezone / 3600),
-        int((time.timezone - int(time.timezone / 3600) * 3600) / 60),
+    return (
+        f"{('+', '-')[time.timezone > 0]}"
+        f"{int(time.timezone / 3600):02d}:"
+        f"{int((time.timezone - int(time.timezone / 3600) * 3600) / 60):02d}"
     )
 
 

--- a/packages/pegasus-python/src/Pegasus/service/ensembles/commands.py
+++ b/packages/pegasus-python/src/Pegasus/service/ensembles/commands.py
@@ -325,17 +325,17 @@ class StatusCommand(EnsembleClientCommand):
 
         result = response.json()
 
-        print("ID:           {}".format(result["id"]))
-        print("Name:         {}".format(result["name"]))
-        print("Plan Command: {}".format(result["plan_command"]))
-        print("Created:      {}".format(formatts(result["created"])))
-        print("Updated:      {}".format(formatts(result["updated"])))
-        print("State:        {}".format(result["state"]))
+        print(f"ID:           {result['id']}")
+        print(f"Name:         {result['name']}")
+        print(f"Plan Command: {result['plan_command']}")
+        print(f"Created:      {formatts(result['created'])}")
+        print(f"Updated:      {formatts(result['updated'])}")
+        print(f"State:        {result['state']}")
         print("UUID:         %s" % (result["wf_uuid"] or ""))
-        print("Priority:     {}".format(result["priority"]))
-        print("Base Dir:     {}".format(result["basedir"]))
+        print(f"Priority:     {result['priority']}")
+        print(f"Base Dir:     {result['basedir']}")
         print("Submit Dir:   %s" % (result["submitdir"] or ""))
-        print("Log:          {}".format(result["log"]))
+        print(f"Log:          {result['log']}")
 
 
 class AnalyzeCommand(EnsembleClientCommand):

--- a/packages/pegasus-python/src/Pegasus/service/ensembles/trigger.py
+++ b/packages/pegasus-python/src/Pegasus/service/ensembles/trigger.py
@@ -111,13 +111,7 @@ class TriggerManager(threading.Thread):
         t.start()
 
         # update state
-        self.log.debug(
-            "changing {name} state: {old_state} -> {new_state}".format(
-                name=trigger_name,
-                old_state=trigger.state,
-                new_state="RUNNING",
-            )
-        )
+        self.log.debug(f"changing {trigger_name} state: {trigger.state} -> RUNNING")
         self.trigger_dao.update_state(
             ensemble_id=trigger.ensemble_id, trigger_id=trigger._id, new_state="RUNNING"
         )

--- a/packages/pegasus-python/src/Pegasus/statistics.py
+++ b/packages/pegasus-python/src/Pegasus/statistics.py
@@ -1220,29 +1220,17 @@ class PegasusStatistics:
 
             # Time summary
             if not self.multiple_wf:
-                writer.write(
-                    "{:<57}: {}\n".format("Workflow wall time", format_seconds(wwt))
-                )
+                writer.write(f"{'Workflow wall time':<57}: {format_seconds(wwt)}\n")
 
+            writer.write(f"{'Cumulative job wall time':<57}: {format_seconds(wcjwt)}\n")
             writer.write(
-                "{:<57}: {}\n".format("Cumulative job wall time", format_seconds(wcjwt))
+                f"{'Cumulative job wall time as seen from submit side':<57}: {format_seconds(ssjwt)}\n"
             )
             writer.write(
-                "{:<57}: {}\n".format(
-                    "Cumulative job wall time as seen from submit side",
-                    format_seconds(ssjwt),
-                )
+                f"{'Cumulative job badput wall time':<57}: {format_seconds(wcbpt)}\n"
             )
             writer.write(
-                "{:<57}: {}\n".format(
-                    "Cumulative job badput wall time", format_seconds(wcbpt)
-                )
-            )
-            writer.write(
-                "{:<57}: {}\n".format(
-                    "Cumulative job badput wall time as seen from submit side",
-                    format_seconds(ssbpt),
-                )
+                f"{'Cumulative job badput wall time as seen from submit side':<57}: {format_seconds(ssbpt)}\n"
             )
 
             ## Integrity summary

--- a/test/core/024-sc4-gridftp-http/run-bamboo-test
+++ b/test/core/024-sc4-gridftp-http/run-bamboo-test
@@ -28,7 +28,7 @@ echo "Running Rosetta.py"
 export PYTHONPATH=$(pegasus-config --python)
 python3.12 Rosetta.py 2>&1 | tee plan.out
 
-WORK_DIR=`cat plan.out | grep submit_dir | awk '{print $NF}' | sed -e 's/[",]//g'`
+WORK_DIR=`cat plan.out | grep pegasus-run | sed -E 's/^pegasus-run[ ]+//'`
 echo "Looks like the workflow directory is: $WORK_DIR"
 cd $WORK_DIR
 


### PR DESCRIPTION
## Summary

Cleanup of deprecated Python patterns across the codebase, plus a fix to the `024-sc4-gridftp-http` test harness.

Commits:
- **test: grep on `pegasus-run` instead of `submit_dir`** (`024-sc4-gridftp-http/run-bamboo-test`) — the harness greped `plan.out` for a JSON `submit_dir` key, but `Rosetta.py` plans via the Python API without `json=True`, so the planner emits human-readable verbose output with no `submit_dir` token. `WORK_DIR` resolved empty → `cd $HOME` → `pegasus-run` failed with "not a valid submit-dir". Reverted to extracting the dir from the `pegasus-run <dir>` epilog line, which the planner actually prints.
- **refactor: convert `str.format()` calls to f-strings** (source + tests).
- **chore: replace deprecated `os.system` calls with stdlib equivalents.**

## Test plan
- `024-sc4-gridftp-http` submit-dir extraction now matches the planner's actual stdout (verified against the failing CI trace, which contained the `pegasus-run <dir>` line).
- f-string / stdlib refactors are behavior-preserving.