### PR TITLE
Remove legacy braindump.txt support; standardize on braindump.yml

### DIFF
--- a/doc/sphinx/manpages/pegasus-analyzer.rst
+++ b/doc/sphinx/manpages/pegasus-analyzer.rst
@@ -86,7 +86,7 @@ Options
    This way, multiple workflow files can be stored in the same
    directory. **pegasus-analyzer** has built-in logic to find the
    specific *jobstate.log* file by looking at the workflow
-   *braindump.txt* file first and figuring out the corresponding
+   *braindump.yml* file first and figuring out the corresponding
    *wf_uuid.* If *output_dir* does not exist, it will be created.
 
 **--dag** 'dag_filename
@@ -138,7 +138,7 @@ Options
    This option is used to specify an alternative property file, which
    may contain the path to the database to be used by
    **pegasus-analyzer**. If this option is not specified, the config
-   file specified in the **braindump.txt** file will take precedence.
+   file specified in the **braindump.yml** file will take precedence.
 
 **--files**
    This option allows users to run **pegasus-analyzer** using the files

--- a/doc/sphinx/manpages/pegasus-monitord.rst
+++ b/doc/sphinx/manpages/pegasus-monitord.rst
@@ -77,8 +77,8 @@ Options
 **--conf** *properties_file*
    is an alternative file containing properties in the *key=value*
    format, and allows users to override values read from the
-   *braindump.txt* file. This option has precedence over the properties
-   file specified in the *braindump.txt* file. Please note that these
+   *braindump.yml* file. This option has precedence over the properties
+   file specified in the *braindump.yml* file. Please note that these
    properties will apply not only to the main workflow, but also to all
    sub-workflows found.
 
@@ -233,7 +233,7 @@ will launch **pegasus-monitord** in replay mode. In this case, if a
 *jobstate.log* file already exists, it will be rotated and a new file
 will be created. If a *diamond-0.stampede.db* SQLite database already
 exists, **pegasus-monitord** will purge all references to the workflow
-id specified in the *braindump.txt* file, including all sub-workflows
+id specified in the *braindump.yml* file, including all sub-workflows
 associated with that workflow id.
 
 ::

--- a/doc/sphinx/user-guide/monitoring-debugging-stats.rst
+++ b/doc/sphinx/user-guide/monitoring-debugging-stats.rst
@@ -1261,7 +1261,7 @@ notification script is starts:
    for human readability).
 
 -  ``PEGASUS_SUBMIT_DIR``: The submit directory for the workflow (usually
-   the value from "submit_dir" in the braindump.txt file)
+   the value from "submit_dir" in the braindump.yml file)
 
 -  ``PEGASUS_STDOUT``: For workflow notifications, this will correspond to
    the dagman.out file for that workflow. For job and invocation

--- a/packages/pegasus-common/src/Pegasus/client/analyzer.py
+++ b/packages/pegasus-common/src/Pegasus/client/analyzer.py
@@ -978,7 +978,7 @@ class AnalyzeFiles(BaseAnalyze):
                 "jobstate.log older than the dagman.out file, workflow logs may not be up to date..."
             )
 
-        # Try to parse workflow parameters from braindump.txt file
+        # Try to parse workflow parameters from braindump.yml file
         wfparams = utils.slurp_braindb(self.options.input_dir)
         if "submit_dir" in wfparams:
             self.options.workflow_base_dir = os.path.normpath(wfparams["submit_dir"])
@@ -1111,12 +1111,12 @@ class AnalyzeFiles(BaseAnalyze):
         try:
             my_wf_params = utils.slurp_braindb(input_dir)
         except Exception:
-            raise AnalyzerError("cannot read braindump.txt file... exiting...")
+            raise AnalyzerError("cannot read braindump.yml file... exiting...")
 
         if "wf_uuid" in my_wf_params:
             return my_wf_params["wf_uuid"] + "-" + self.jsdl_filename
 
-        raise AnalyzerError("braindump.txt does not contain wf_uuid... exiting...")
+        raise AnalyzerError("braindump.yml does not contain wf_uuid... exiting...")
 
     def parse_dag_file(self, dag_fn) -> None:
         """This function walks through the dag file, learning about

--- a/packages/pegasus-common/test/client/test_analyzer.py
+++ b/packages/pegasus-common/test/client/test_analyzer.py
@@ -804,7 +804,7 @@ class TestAnalyzeFiles:
         with pytest.raises(Exception) as err:
             analyze.get_jsdl_filename(input_dir)
 
-        assert str(err.value) == "cannot read braindump.txt file... exiting..."
+        assert str(err.value) == "cannot read braindump.yml file... exiting..."
         assert AnalyzerError == err.type
 
     def test_get_jsdl_filename_no_wf_uuid(self, mocker, AnalyzerFiles):
@@ -815,7 +815,7 @@ class TestAnalyzeFiles:
         with pytest.raises(Exception) as err:
             analyze.get_jsdl_filename(input_dir)
 
-        assert str(err.value) == "braindump.txt does not contain wf_uuid... exiting..."
+        assert str(err.value) == "braindump.yml does not contain wf_uuid... exiting..."
         assert AnalyzerError == err.type
 
     def test_parse_dag_file(self, mocker, capsys, AnalyzerFiles):

--- a/packages/pegasus-python/src/Pegasus/cli/pegasus-metadata.py
+++ b/packages/pegasus-python/src/Pegasus/cli/pegasus-metadata.py
@@ -54,9 +54,8 @@ def configure_logging(verbosity=0):
 
 def get_workflow_uuid(submit_dir):
     bdump_yml = Path(submit_dir) / "braindump.yml"
-    bdump_txt = Path(submit_dir) / "braindump.txt"
 
-    if bdump_yml.exists() is False and bdump_txt.exists() is False:
+    if bdump_yml.exists() is False:
         raise ValueError(f"Not a valid workflow submit directory: {submit_dir!r}")
 
     braindump = utils.slurp_braindb(submit_dir)

--- a/packages/pegasus-python/src/Pegasus/db/connection.py
+++ b/packages/pegasus-python/src/Pegasus/db/connection.py
@@ -370,9 +370,9 @@ def get_wf_uuid(submit_dir):
     # Getting values from the submit_dir braindump file
     top_level_wf_params = utils.slurp_braindb(submit_dir)
 
-    # Return if we cannot parse the braindump.txt file
+    # Return if we cannot parse the braindump.yml file
     if not top_level_wf_params:
-        log.error(f"Unable to process braindump.txt in {submit_dir}")
+        log.error(f"Unable to process braindump.yml in {submit_dir}")
         return None
 
     # Get wf_uuid for this workflow
@@ -380,7 +380,7 @@ def get_wf_uuid(submit_dir):
     if "wf_uuid" in top_level_wf_params:
         wf_uuid = top_level_wf_params["wf_uuid"]
     else:
-        log.error("workflow id cannot be found in the braindump.txt ")
+        log.error("workflow id cannot be found in the braindump.yml ")
         return None
 
     return wf_uuid
@@ -556,7 +556,7 @@ def _get_workflow_uri(props=None, submit_dir=None, top_dir=None):
     if "dag" in top_level_wf_params:
         dag_file_name = top_level_wf_params["dag"]
     else:
-        raise ConnectionError("DAG file name cannot be found in the braindump.txt.")
+        raise ConnectionError("DAG file name cannot be found in the braindump.yml.")
 
     # Create the sqlite db url
     dag_file_name = os.path.basename(dag_file_name)
@@ -688,9 +688,9 @@ def _parse_top_level_wf_params(submit_dir, top_dir):
 
     top_level_wf_params = utils.slurp_braindb(dir)
 
-    # Return if we cannot parse the braindump.txt file
+    # Return if we cannot parse the braindump.yml file
     if not top_level_wf_params:
-        raise ConnectionError(f"File 'braindump.txt' not found in {dir}.")
+        raise ConnectionError(f"File 'braindump.yml' not found in {dir}.")
 
     if top_level_wf_params["root_wf_uuid"] == top_level_wf_params["wf_uuid"]:
         return top_level_wf_params
@@ -709,7 +709,7 @@ def _parse_top_level_wf_params(submit_dir, top_dir):
             break
 
     if not top_level_wf_params:
-        raise ConnectionError("Unable to find file 'braindump.txt' in parent folders.")
+        raise ConnectionError("Unable to find file 'braindump.yml' in parent folders.")
 
     return top_level_wf_params
 

--- a/packages/pegasus-python/src/Pegasus/db/schema.py
+++ b/packages/pegasus-python/src/Pegasus/db/schema.py
@@ -248,7 +248,7 @@ class Workflow(Base):
 
     __tablename__ = "workflow"
 
-    # ==> Information comes from braindump.txt file
+    # ==> Information comes from braindump.yml file
     wf_id = Column("wf_id", KeyInteger, primary_key=True)
     wf_uuid = Column("wf_uuid", String(255), nullable=False)
     dag_file_name = Column("dag_file_name", String(255))
@@ -1003,7 +1003,7 @@ class MasterWorkflow(Base):
 
     __tablename__ = "master_workflow"
 
-    # ==> Information comes from braindump.txt file
+    # ==> Information comes from braindump.yml file
     wf_id = Column("wf_id", KeyInteger, primary_key=True)
     wf_uuid = Column("wf_uuid", String(255), nullable=False)
     dax_label = Column("dax_label", String(255))

--- a/packages/pegasus-python/src/Pegasus/submitdir.py
+++ b/packages/pegasus-python/src/Pegasus/submitdir.py
@@ -15,6 +15,7 @@ from os.path import expanduser
 
 from sqlalchemy import select
 
+from Pegasus import braindump
 from Pegasus.command import CompoundCommand, LoggingCommand
 from Pegasus.db import connection
 from Pegasus.db.schema import (
@@ -134,8 +135,6 @@ class SubmitDir:
             raise SubmitDirException(f"Invalid submit dir: {submitdir}")
 
         self.braindump_file = os.path.join(self.submitdir, "braindump.yml")
-        if not os.path.isfile(self.braindump_file):
-            self.braindump_file = os.path.join(self.submitdir, "braindump.txt")
 
         # Read the braindump file
         self.braindump = utils.slurp_braindb(os.path.join(self.submitdir))
@@ -287,7 +286,7 @@ class SubmitDir:
             raise SubmitDirException(f"Destination is a file: {dest}")
 
         if os.path.isdir(dest):
-            if os.path.exists(os.path.join(dest, "braindump.txt")):
+            if os.path.exists(os.path.join(dest, "braindump.yml")):
                 raise SubmitDirException(f"Destination is a submit dir: {dest}")
             dest = os.path.join(dest, os.path.basename(self.submitdir))
 
@@ -350,7 +349,8 @@ class SubmitDir:
         # Set new paths in the braindump file
         self.braindump["submit_dir"] = dest
         self.braindump["basedir"] = os.path.dirname(dest)
-        utils.write_braindump(os.path.join(dest, "braindump.txt"), self.braindump)
+        with open(os.path.join(dest, "braindump.yml"), "w") as f:
+            braindump.dump(braindump.Braindump(**self.braindump), f)
 
         # Note that we do not need to update the properties file even though it
         # might contain DB URLs because it cannot contain a DB URL with the submit

--- a/packages/pegasus-python/src/Pegasus/tools/properties.py
+++ b/packages/pegasus-python/src/Pegasus/tools/properties.py
@@ -231,7 +231,7 @@ class Properties:
         properties file. config_file is the properties file passed via
         the --conf command-line option, it has the highest
         priority. rundir_propfile is the properties file in the run
-        directory (specified in the braindump.txt file with the
+        directory (specified in the braindump.yml file with the
         properties tag. It has the second highest priority. If those
         are not specified, we try to lost $(HOME)/.pegasusrc, as a
         last resort.

--- a/packages/pegasus-python/src/Pegasus/tools/utils.py
+++ b/packages/pegasus-python/src/Pegasus/tools/utils.py
@@ -50,7 +50,6 @@ re_remove_extensions = re.compile(r"(?:\.(?:rescue|dag))+$")
 # Module variables
 MAXLOGFILE = 1000  # For log rotation, check files from .000 to .999
 jobbase = "jobstate.log"  # Default name for jobstate.log file
-brainbase = "braindump.txt"  # Default name for workflow information file
 
 logger = logging.getLogger(__name__)
 
@@ -345,76 +344,12 @@ def find_exec(program, curdir=False, otherdirs=[]):
     return None
 
 
-# TODO: Remove, only used in pegasus-submitdir
-def write_braindump(filename, items):
-    "This simply writes a dict to the file specified in braindump format"
-    f = open(filename, "w")
-    for k in items:
-        f.write(f"{k} {items[k]}\n")
-    f.close()
-
-
-# TODO: Remove, only used in pegasus-submitdir
-def read_braindump(filename):
-    "This simply reads a braindump dict from the file specified"
-    items = {}
-    f = open(filename)
-    for line in f:
-        k, v = line.strip().split(" ", 1)
-        k = k.strip()
-        v = v.strip()
-        items[k] = v
-    f.close()
-    return items
-
-
-def _slurp_braindb(run, brain_alternate=None):
-    """
-    Reads extra configuration from braindump database
-    Param: run is the run directory
-    Returns: Dictionary with the configuration, empty if error
-    """
-    my_config = {}
-
-    if brain_alternate is None:
-        my_braindb = os.path.join(run, "braindump.txt")
-    else:
-        my_braindb = os.path.join(run, brain_alternate)
-
-    try:
-        my_file = open(my_braindb)
-    except OSError:
-        # Error opening file
-        return my_config
-
-    for line in my_file:
-        # Remove \r and/or \n from the end of the line
-        line = line.rstrip("\r\n")
-        # Split the line into a key and a value
-        k, v = line.split(" ", 1)
-
-        if k == "run" and v != run and run != ".":
-            logger.warning(f"run directory mismatch, using {run}")
-            my_config[k] = run
-        else:
-            # Remove leading and trailing whitespaces from value
-            v = v.strip()
-            my_config[k] = v
-
-    # Close file
-    my_file.close()
-
-    # Done!
-    logger.debug(f"# slurped {my_braindb}")
-    return my_config
-
-
 def slurp_braindb(run_dir, brain_alternate=None):
     """
     Load the braindump file from *run_dir* and return its contents as a ``dict``.
 
-    Prefers ``braindump.yml`` (YAML). Falls back to the legacy ``braindump.txt``
-    format for pre-5.0 workflows.
+    Reads the ``braindump.yml`` (YAML) file written by the planner. Returns an
+    empty ``dict`` if the file does not exist.
 
     :param run_dir: Path to the workflow submit directory.
     :type run_dir: str
@@ -432,20 +367,14 @@ def slurp_braindb(run_dir, brain_alternate=None):
     )
 
     if bdump.exists() is False:
-        # TODO: Remove this except block one backwards compatibility for
-        # 4.9 is not needed.
-        cfg = _slurp_braindb(run_dir, brain_alternate)
-    else:
-        if bdump.is_file() is False:
-            raise TypeError(f"{bdump.resolve()} is not a valid file")
+        return {}
 
-        with bdump.open("r") as fp:
-            cfg = braindump.load(fp)
-            cfg = {
-                k: str(v) if isinstance(v, Path) else v for k, v in asdict(cfg).items()
-            }
+    if bdump.is_file() is False:
+        raise TypeError(f"{bdump.resolve()} is not a valid file")
 
-    return cfg
+    with bdump.open("r") as fp:
+        cfg = braindump.load(fp)
+        return {k: str(v) if isinstance(v, Path) else v for k, v in asdict(cfg).items()}
 
 
 def raw_to_regular(exitcode):

--- a/src/edu/isi/pegasus/planner/code/generator/Braindump.java
+++ b/src/edu/isi/pegasus/planner/code/generator/Braindump.java
@@ -381,12 +381,12 @@ public class Braindump {
     }
 
     /**
-     * Writes out the braindump.txt file for a workflow in the submit directory. The braindump.txt
+     * Writes out the braindump.yml file for a workflow in the submit directory. The braindump.yml
      * file is used for passing to the tailstatd daemon that monitors the state of execution of the
      * workflow.
      *
      * @param entries the Map containing the entries going into the braindump file.
-     * @return the absolute path to the braindump file.txt written in the directory.
+     * @return the absolute path to the braindump.yml file written in the directory.
      * @throws IOException in case of error while writing out file.
      */
     protected File writeOutBraindumpFile(Map<String, String> entries) throws IOException {

--- a/src/edu/isi/pegasus/planner/code/generator/Metrics.java
+++ b/src/edu/isi/pegasus/planner/code/generator/Metrics.java
@@ -203,7 +203,7 @@ public class Metrics {
             throw new IOException("NULL Metrics passed");
         }
 
-        // create a writer to the braindump.txt in the directory.
+        // create a writer to the metrics file in the directory.
         File f = metrics.getMetricsFileLocationInSubmitDirectory();
 
         if (f == null) {

--- a/src/edu/isi/pegasus/planner/code/generator/PBS.java
+++ b/src/edu/isi/pegasus/planner/code/generator/PBS.java
@@ -69,7 +69,7 @@ public class PBS extends Abstract {
     public Collection<File> generateCode(ADag dag) throws CodeGeneratorException {
         Collection result = new ArrayList(1);
 
-        // create a writer to the braindump.txt in the directory.
+        // create a writer to the PBS file in the directory.
         File f = new File(this.getPathtoPBSFile(dag));
 
         try {


### PR DESCRIPTION
Closes GH-2213.

## What

The planner has written `braindump.yml` since 5.0 (`Braindump.java`: `BRAINDUMP_FILE = "braindump.yml"`). The legacy space-separated `braindump.txt` was only retained as a pre-5.0 read fallback, with an explicit `TODO` to remove it once 4.9 compatibility was no longer needed. This drops it and standardizes on YAML.

## Changes

- **`tools/utils.py`** — deleted the `_slurp_braindb` text parser and the `.txt` fallback branch in `slurp_braindb` (now YAML-only; returns `{}` when the file is absent). Removed the now-dead `write_braindump` / `read_braindump` text helpers and the unused `brainbase` constant.
- **`submitdir.py`** — `move()` now writes real YAML via `braindump.dump(...)` instead of the old space-separated text format. The previous code wrote text content to a file the `.yml`-first reader could not parse (latent bug). Also dropped the `.txt` read fallback in `__init__` and the `.txt` submit-dir detection in `move()`.
- **`cli/pegasus-metadata.py`** — dropped the `.txt` existence check.
- **Messages/comments/tests** — updated stale `braindump.txt` references in `db/connection.py`, `client/analyzer.py` (+ matching `test_analyzer.py` assertions), `db/schema.py`, `tools/properties.py`, and Java javadoc/comments (`Braindump.java`; fixed stale copy-paste comments in `Metrics.java`/`PBS.java`).
- **Docs** — updated current manpages (`pegasus-analyzer`, `pegasus-monitord`) and the user-guide. Historical docs (`release_4.6.x.md`, `migration.rst`) left untouched.

## Verification

- `ruff check` (project config, incl. `RET`) and `ruff format` clean on all edited files.
- Analyzer `jsdl_filename` tests (which assert the updated error strings) pass.
- `move()` YAML round-trip smoke-tested.

Note: full e2e/workflow CI not yet run.