### PR TITLE
Replace os.path usage with pathlib

### DIFF
--- a/packages/pegasus-api/pyproject.toml
+++ b/packages/pegasus-api/pyproject.toml
@@ -89,7 +89,7 @@ extend-select = [
     "TID", # flake8-tidy-imports
     "TC",  # flake8-type-checking
     # "ARG", # flake8-unused-arguments
-    # "PTH", # flake8-use-pathlib
+    "PTH", # flake8-use-pathlib
     "I",   # isort
     "UP",  # pyupgrade
 ]

--- a/packages/pegasus-api/src/Pegasus/api/mixins.py
+++ b/packages/pegasus-api/src/Pegasus/api/mixins.py
@@ -348,14 +348,14 @@ class ProfileMixin:
         # add profile(s)
         if key and value:
             if isinstance(value, Path) or type(value) is bool:
-                # convert pathlib.Path and bool to str
+                # convert Path and bool to str
                 value = str(value)
 
             self.profiles[ns].update({key: value})
         else:
             for k, v in kw.items():
                 if isinstance(v, Path) or type(v) is bool:
-                    # convert pathlib.Path, bool, to str
+                    # convert Path, bool, to str
                     kw[k] = str(v)
 
             self.profiles[ns].update(kw)

--- a/packages/pegasus-api/src/Pegasus/api/properties.py
+++ b/packages/pegasus-api/src/Pegasus/api/properties.py
@@ -387,7 +387,7 @@ class Properties:
             file = "pegasus.properties"
 
         if isinstance(file, (str, Path)):
-            with open(file, "w") as f:
+            with Path(file).open("w") as f:
                 f.write(props)
         elif hasattr(file, "read"):
             file.write(props)

--- a/packages/pegasus-api/src/Pegasus/api/replica_catalog.py
+++ b/packages/pegasus-api/src/Pegasus/api/replica_catalog.py
@@ -265,7 +265,7 @@ class ReplicaCatalog(Writable):
         :type checksum: Optional[Dict[str, str]], optional
         :param metadata: metadata key value pairs associated with this lfn such as :code:`{"created": "Thu Jun 18 22:18:36 PDT 2020", "owner": "pegasus"}`, defaults to None
         :type metadata: Optional[Dict[str, Union[int, str, float]]], optional
-        :raises ValueError: if pfn is given as a :code:`pathlib.Path`, it must be an absolute path
+        :raises ValueError: if pfn is given as a :code:`Path`, it must be an absolute path
         :raises ValueError: an unsupported checksum type was given
         """
 
@@ -279,9 +279,7 @@ class ReplicaCatalog(Writable):
             pfn = str(pfn)
 
         if isinstance(pfn, File):
-            raise TypeError(
-                f"Invalid pfn: {pfn}, the given pfn must be a str or pathlib.Path"
-            )
+            raise TypeError(f"Invalid pfn: {pfn}, the given pfn must be a str or Path")
 
         metadata = metadata or OrderedDict()
         checksum = checksum or OrderedDict()

--- a/packages/pegasus-api/src/Pegasus/api/transformation_catalog.py
+++ b/packages/pegasus-api/src/Pegasus/api/transformation_catalog.py
@@ -195,7 +195,7 @@ class TransformationSite(ProfileMixin, MetadataMixin):
         :type container: Optional[Union[Container, str]], optional
         :raises TypeError: arch must be one of :py:class:`~Pegasus.api.site_catalog.Arch`
         :raises TypeError: os_type must be one of :py:class:`~Pegasus.api.site_catalog.OS`
-        :raises ValueError: pfn must be given as an absolute path when :code:`pathlib.Path` is used
+        :raises ValueError: pfn must be given as an absolute path when :code:`Path` is used
         :raises ValueError: :code:`bypass_staging=True` can only be used when :code:`is_stageable=True`
         """
 
@@ -379,7 +379,7 @@ class Transformation(ProfileMixin, HookMixin, MetadataMixin):
         :raises TypeError: arch must be one of :py:class:`~Pegasus.api.site_catalog.Arch`
         :raises TypeError: os_type must be one of :py:class:`~Pegasus.api.site_catalog.OS`
         :raises ValueError: fields: namespace, name, and field must not contain any :code:`:` (colons)
-        :raises ValueError: pfn must be given as an absolute path when :code:`pathlib.Path` is used
+        :raises ValueError: pfn must be given as an absolute path when :code:`Path` is used
         :raises ValueError: :code:`bypass_staging=True` can only be used when :code:`is_stageable=True`
         """
 

--- a/packages/pegasus-api/src/Pegasus/api/workflow.py
+++ b/packages/pegasus-api/src/Pegasus/api/workflow.py
@@ -599,7 +599,7 @@ class SubWorkflow(AbstractJob):
         :type relative_dir: Optional[Union[str, Path]]
         :param relative_submit_dir: the relative submit directory where to generate the concrete workflow. Overrides relative_dir, defaults to None
         :type relative_submit_dir: Optional[Union[str, Path]]
-        :param random_dir: if set to :code:`True`, a random timestamp based name will be used for the execution directory that is created by the create dir jobs; else if a path is given as a :code:`str` or :code:`pathlib.Path`, then that will be used as the basename of the directory that is to be created, defaults to False
+        :param random_dir: if set to :code:`True`, a random timestamp based name will be used for the execution directory that is created by the create dir jobs; else if a path is given as a :code:`str` or :code:`Path`, then that will be used as the basename of the directory that is to be created, defaults to False
         :type random_dir: Union[bool, str, Path], optional
         :param inherited_rc_files: comma separated list of replica files, defaults to None
         :type inherited_rc_files: Optional[List[Union[str, Path]]]
@@ -1117,7 +1117,7 @@ class Workflow(Writable, HookMixin, ProfileMixin, MetadataMixin):
         :type dir: Optional[Union[str, Path]]
         :param relative_dir: the relative directory to the base directory where to generate the concrete workflow, defaults to None
         :type relative_dir: Optional[Union[str, Path]]
-        :param random_dir: if set to :code:`True`, a random timestamp based name will be used for the execution directory that is created by the create dir jobs; else if a path is given as a :code:`str` or :code:`pathlib.Path`, then that will be used as the basename of the directory that is to be created, defaults to False
+        :param random_dir: if set to :code:`True`, a random timestamp based name will be used for the execution directory that is created by the create dir jobs; else if a path is given as a :code:`str` or :code:`Path`, then that will be used as the basename of the directory that is to be created, defaults to False
         :type random_dir: Union[bool, str, Path], optional
         :param relative_submit_dir: the relative submit directory where to generate the concrete workflow. Overrides relative_dir, defaults to None
         :type relative_submit_dir: Optional[Union[str, Path]]

--- a/packages/pegasus-api/src/Pegasus/api/writable.py
+++ b/packages/pegasus-api/src/Pegasus/api/writable.py
@@ -144,7 +144,7 @@ class Writable:
             path = Path(file)
             ext = path.suffix[1:].lower()
 
-            with open(file, "w") as f:
+            with path.open("w") as f:
                 if ext in Writable._FORMATS:
                     self._write(f, ext)
                 else:

--- a/packages/pegasus-api/test/api/conftest.py
+++ b/packages/pegasus-api/test/api/conftest.py
@@ -1,6 +1,6 @@
 import json
-import os
 import re
+from pathlib import Path
 
 import pytest
 import yaml
@@ -22,13 +22,10 @@ def convert_yaml_schemas_to_json():
     at the end of the test module.
     """
     # get the path of the schema file with the given name
-    path = os.path.dirname(os.path.realpath(__file__))
-    path = path.replace("packages/pegasus-api/test/api", "share/pegasus/schema/yaml")
+    path = Path(__file__).resolve().parents[4] / "share/pegasus/schema/yaml"
 
     json_schemas = {
-        os.path.join(path, filename): os.path.join(
-            path, filename.replace(".yml", ".json")
-        )
+        path / filename: path / filename.replace(".yml", ".json")
         for filename in [
             "common.yml",
             "rc-5.0.yml",
@@ -40,19 +37,19 @@ def convert_yaml_schemas_to_json():
 
     # convert each of the yml schemas to json
     for yml_filename, json_filename in json_schemas.items():
-        with open(yml_filename) as yml_file, open(json_filename, "w") as json_file:
+        with yml_filename.open() as yml_file, json_filename.open("w") as json_file:
             json_str = json.dumps(yaml.safe_load(yml_file))
 
             # for references pointing to '*.yml' files, convert them to point
             # to '.json' files instead
             json_str = re.sub(
                 r"([a-z0-9\-\.]+)(.yml)",
-                os.path.join("file://" + path, r"\1.json"),
+                "file://" + str(path / r"\1.json"),
                 json_str,
             )
 
             json_obj = json.loads(json_str)
-            json_obj["$id"] = "file://" + json_filename
+            json_obj["$id"] = "file://" + str(json_filename)
 
             json.dump(json_obj, json_file, indent=4)
 
@@ -60,7 +57,7 @@ def convert_yaml_schemas_to_json():
 
     # cleanup
     for _, json_schema in json_schemas.items():
-        os.remove(json_schema)
+        json_schema.unlink()
 
 
 @pytest.fixture(scope="function")
@@ -71,13 +68,9 @@ def load_schema():
 
     def _load_schema(name):
         # get the path of the schema file with the given name
-        path = os.path.dirname(os.path.realpath(__file__))
-        path = path.replace(
-            "packages/pegasus-api/test/api", "share/pegasus/schema/yaml"
-        )
-        path = os.path.join(path, name)
+        path = Path(__file__).resolve().parents[4] / "share/pegasus/schema/yaml" / name
 
-        with open(path) as f:
+        with path.open() as f:
             return json.load(f)
 
     return _load_schema

--- a/packages/pegasus-api/test/api/test_properties.py
+++ b/packages/pegasus-api/test/api/test_properties.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from configparser import DEFAULTSECT
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -210,8 +209,8 @@ def test_write_default_file(props):
     props["pegasus.mode"] = "development"
     props.write()
 
-    EXPECTED_DEFAULT_FILE = "pegasus.properties"
-    with open(EXPECTED_DEFAULT_FILE) as f:
+    EXPECTED_DEFAULT_FILE = Path("pegasus.properties")
+    with EXPECTED_DEFAULT_FILE.open() as f:
         assert f.read() == "pegasus.mode = development\n\n"
 
-    os.remove(EXPECTED_DEFAULT_FILE)
+    EXPECTED_DEFAULT_FILE.unlink()

--- a/packages/pegasus-api/test/api/test_replica_catalog.py
+++ b/packages/pegasus-api/test/api/test_replica_catalog.py
@@ -228,10 +228,7 @@ class TestReplicaCatalog:
         with pytest.raises(TypeError) as e:
             rc.add_replica(site="local", lfn="test_lfn", pfn=File("badfile"))
 
-        assert (
-            "Invalid pfn: badfile, the given pfn must be a str or pathlib.Path"
-            in str(e)
-        )
+        assert "Invalid pfn: badfile, the given pfn must be a str or Path" in str(e)
 
     def test_add_replica_file_as_lfn(self):
         rc = ReplicaCatalog()

--- a/packages/pegasus-api/test/api/test_transformation_catalog.py
+++ b/packages/pegasus-api/test/api/test_transformation_catalog.py
@@ -185,7 +185,7 @@ class TestTransformationSite:
 
     def test_invalid_pfn(self):
         with pytest.raises(ValueError) as e:
-            TransformationSite("local", Path("."), False)
+            TransformationSite("local", Path(), False)
 
         assert "invalid pfn" in str(e)
 
@@ -322,9 +322,7 @@ class TestTransformation:
 
     def test_invalid_pfn(self):
         with pytest.raises(ValueError) as e:
-            Transformation(
-                "executable", site="local", pfn=Path("."), is_stageable=False
-            )
+            Transformation("executable", site="local", pfn=Path(), is_stageable=False)
 
         assert "invalid pfn" in str(e)
 

--- a/packages/pegasus-api/test/api/test_workflow.py
+++ b/packages/pegasus-api/test/api/test_workflow.py
@@ -1,6 +1,5 @@
 import getpass
 import json
-import os
 import re
 import shutil
 from pathlib import Path
@@ -1357,7 +1356,7 @@ class TestWorkflow:
         # _path should be set by the call to write
         assert wf._path == path
 
-        with open(path) as f:
+        with Path(path).open() as f:
             result = yaml.safe_load(f)
 
         workflow_schema = load_schema("wf-5.0.json")
@@ -1377,13 +1376,13 @@ class TestWorkflow:
         del result["x-pegasus"]
         assert result == expected_json
 
-        os.remove(path)
+        Path(path).unlink()
 
     def test_write_default_filename(self, wf, expected_json):
         wf.write()
-        EXPECTED_FILE = "workflow.yml"
+        EXPECTED_FILE = Path("workflow.yml")
 
-        with open(EXPECTED_FILE) as f:
+        with EXPECTED_FILE.open() as f:
             result = yaml.safe_load(f)
 
         result["jobs"] = sorted(result["jobs"], key=lambda j: j["id"])
@@ -1399,7 +1398,7 @@ class TestWorkflow:
         del result["x-pegasus"]
         assert result == expected_json
 
-        os.remove(EXPECTED_FILE)
+        EXPECTED_FILE.unlink()
 
     def test_write_wf_catalogs_included(self):
         wf = Workflow("test")
@@ -1681,7 +1680,7 @@ class TestWorkflow:
             **{"+property.key-_": "value"},
         )
 
-        os.remove(path)
+        Path(path).unlink()
 
     def test_Path_args_parsed_correctly_in_plan(self, wf, mocker):
         mocker.patch("shutil.which", return_value="/usr/bin/pegasus-version")
@@ -1734,7 +1733,7 @@ class TestWorkflow:
             **{"pegasus.mode": "development"},
         )
 
-        os.remove(path)
+        Path(path).unlink()
 
     @pytest.mark.parametrize(
         "random_dir, expected_kwargs",
@@ -1847,7 +1846,7 @@ class TestWorkflow:
 
         Pegasus.client._client.Client.plan.assert_called_once_with(**expected_kwargs)
 
-        os.remove(path)
+        Path(path).unlink()
 
     def test_plan_workflow_not_written(self, wf, mocker):
         mocker.patch("shutil.which", return_value="/usr/bin/pegasus-version")
@@ -1892,7 +1891,7 @@ class TestWorkflow:
             verbose=0,
         )
 
-        os.remove(DEFAULT_WF_PATH)
+        Path(DEFAULT_WF_PATH).unlink()
 
     def test_plan_workflow_and_access_braindump_file(self, wf, mocker):
         # shutil.which used in _client.from_env()
@@ -1914,7 +1913,7 @@ class TestWorkflow:
             assert wf.braindump.user == "ryan"
             assert wf.braindump.submit_dir == Path("/submit_dir")
 
-            os.remove(DEFAULT_WF_PATH)
+            Path(DEFAULT_WF_PATH).unlink()
 
     def test_access_braindump_file_before_workflow_planned(self):
         with pytest.raises(PegasusError) as e:

--- a/packages/pegasus-api/test/api/test_writable.py
+++ b/packages/pegasus-api/test/api/test_writable.py
@@ -1,6 +1,5 @@
 import getpass
 import json
-import os
 from io import StringIO
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryFile
@@ -84,7 +83,8 @@ class Test_CustomEncoder:
 class TestWritable:
     def test_write_using_defaults(self, writable_obj, expected, mocker):
         writable_obj.write()
-        with open("container.yml") as f:
+        path = Path("container.yml")
+        with path.open() as f:
             result = yaml.safe_load(f)
 
             # TODO: check that keys in x-pegasus exist and then del x-pegasus
@@ -93,7 +93,7 @@ class TestWritable:
             expected["x-pegasus"]["createdOn"] = result["x-pegasus"]["createdOn"]
             assert result == expected
 
-        os.remove("container.yml")
+        path.unlink()
 
     @pytest.mark.parametrize(
         "file, _format, loader",
@@ -110,7 +110,8 @@ class TestWritable:
     )
     def test_write_using_str_input(self, writable_obj, expected, file, _format, loader):
         writable_obj.write(file, _format=_format)
-        with open(file) as f:
+        path = Path(file)
+        with path.open() as f:
             result = loader(f)
 
             # setting dates to be the same as it won't be safe to compare them
@@ -118,7 +119,7 @@ class TestWritable:
             expected["x-pegasus"]["createdOn"] = result["x-pegasus"]["createdOn"]
             assert result == expected
 
-        os.remove(file)
+        path.unlink()
 
     @pytest.mark.parametrize(
         "file, _format, loader",
@@ -136,7 +137,8 @@ class TestWritable:
     def test_write_using_file_input(
         self, writable_obj, expected, file, _format, loader
     ):
-        with open(file, "w+") as f:
+        path = Path(file)
+        with path.open("w+") as f:
             writable_obj.write(f, _format=_format)
             f.seek(0)
             result = loader(f)
@@ -146,7 +148,7 @@ class TestWritable:
             expected["x-pegasus"]["createdOn"] = result["x-pegasus"]["createdOn"]
             assert result == expected
 
-        os.remove(file)
+        path.unlink()
 
     def test_write_invalid_format(self, writable_obj):
         with pytest.raises(ValueError):
@@ -196,14 +198,14 @@ class TestWritable:
         assert writable_obj._path == str(Path(writable_obj._DEFAULT_FILENAME).resolve())
         assert writable_obj.path == Path(writable_obj._DEFAULT_FILENAME).resolve()
         writable_obj._path = None
-        os.remove(str(Path(writable_obj._DEFAULT_FILENAME).resolve()))
+        Path(writable_obj._DEFAULT_FILENAME).resolve().unlink()
 
     def test_set_path_given_str_filename(self, writable_obj):
         writable_obj.write("filename")
         assert writable_obj._path == str(Path("filename").resolve())
         assert writable_obj.path == Path("filename").resolve()
         writable_obj._path = None
-        os.remove("filename")
+        Path("filename").unlink()
 
     def test_set_path_given_NamedTemporaryFile(self, writable_obj):
         f = NamedTemporaryFile(mode="w")

--- a/packages/pegasus-common/pyproject.toml
+++ b/packages/pegasus-common/pyproject.toml
@@ -88,7 +88,7 @@ extend-select = [
     "TID", # flake8-tidy-imports
     "TC",  # flake8-type-checking
     # "ARG", # flake8-unused-arguments
-    # "PTH", # flake8-use-pathlib
+    "PTH", # flake8-use-pathlib
     "I",   # isort
     "UP",  # pyupgrade
 ]

--- a/packages/pegasus-common/src/Pegasus/braindump.py
+++ b/packages/pegasus-common/src/Pegasus/braindump.py
@@ -41,7 +41,7 @@ class Braindump:
     """
 
     def __post_init__(self):
-        """Convert string path fields to :class:`pathlib.Path` and coerce ``uses_pmc`` to bool."""
+        """Convert string path fields to :class:`Path` and coerce ``uses_pmc`` to bool."""
         self.dax = Path(self.dax) if self.dax else self.dax
         self.basedir = Path(self.basedir) if self.basedir else self.basedir
         self.submit_dir = Path(self.submit_dir) if self.submit_dir else self.submit_dir

--- a/packages/pegasus-common/src/Pegasus/client/_client.py
+++ b/packages/pegasus-common/src/Pegasus/client/_client.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import re
 import shutil
 import subprocess
@@ -266,7 +267,7 @@ class Client:
 
         self._pegasus_home = pegasus_home
 
-        base = Path(pegasus_home) / "bin"
+        base = Path(os.path.normpath(Path(pegasus_home) / "bin"))
 
         self._plan = str(base / "pegasus-plan")
         self._run = str(base / "pegasus-run")

--- a/packages/pegasus-common/src/Pegasus/client/_client.py
+++ b/packages/pegasus-common/src/Pegasus/client/_client.py
@@ -6,7 +6,6 @@ import subprocess
 import threading
 import time
 from functools import partial
-from os import path
 from pathlib import Path
 from typing import BinaryIO
 
@@ -47,7 +46,7 @@ def from_env(pegasus_home: str = None):
         if not pegasus_version_path:
             raise ValueError("PEGASUS_HOME not found")
 
-        pegasus_home = path.dirname(path.dirname(pegasus_version_path))
+        pegasus_home = str(Path(pegasus_version_path).parent.parent)
 
     return Client(pegasus_home)
 
@@ -267,15 +266,15 @@ class Client:
 
         self._pegasus_home = pegasus_home
 
-        base = path.normpath(path.join(pegasus_home, "bin"))
+        base = Path(pegasus_home) / "bin"
 
-        self._plan = path.join(base, "pegasus-plan")
-        self._run = path.join(base, "pegasus-run")
-        self._status = path.join(base, "pegasus-status")
-        self._remove = path.join(base, "pegasus-remove")
-        self._analyzer = path.join(base, "pegasus-analyzer")
-        self._statistics = path.join(base, "pegasus-statistics")
-        self._graph = path.join(base, "pegasus-graphviz")
+        self._plan = str(base / "pegasus-plan")
+        self._run = str(base / "pegasus-run")
+        self._status = str(base / "pegasus-status")
+        self._remove = str(base / "pegasus-remove")
+        self._analyzer = str(base / "pegasus-analyzer")
+        self._statistics = str(base / "pegasus-statistics")
+        self._graph = str(base / "pegasus-graphviz")
         self._retrieve_status = status.Status()
 
     def plan(
@@ -1005,11 +1004,14 @@ class Workflow:
         :rtype: Braindump
         :raises WorkflowInstanceError: if the braindump file is not found
         """
+        braindump_path = Path(submit_dir) / "braindump.yml"
         try:
-            with (Path(submit_dir) / "braindump.yml").open("r") as f:
+            with braindump_path.open("r") as f:
                 bd = braindump.load(f)
         except FileNotFoundError:
-            raise WorkflowInstanceError(f"Unable to load braindump file: {path}")
+            raise WorkflowInstanceError(
+                f"Unable to load braindump file: {braindump_path}"
+            )
 
         return bd
 

--- a/packages/pegasus-common/src/Pegasus/client/analyzer.py
+++ b/packages/pegasus-common/src/Pegasus/client/analyzer.py
@@ -469,7 +469,9 @@ class BaseAnalyze:
                             if sub_prop:
                                 if sub_prop.group(1) == "_CONDOR_DAGMAN_LOG":
                                     my_job.dagman_out = sub_prop.group(2)
-                                    my_job.dagman_out = str(Path(my_job.dagman_out))
+                                    my_job.dagman_out = os.path.normpath(
+                                        my_job.dagman_out
+                                    )
                                     if (
                                         my_job.dagman_out.find(
                                             options.workflow_base_dir
@@ -477,16 +479,11 @@ class BaseAnalyze:
                                         >= 0
                                     ):
                                         # Path to dagman_out file includes original submit_dir, let's try to change it
-                                        my_job.dagman_out = str(
-                                            Path(
-                                                my_job.dagman_out.replace(
-                                                    (
-                                                        options.workflow_base_dir
-                                                        + os.sep
-                                                    ),
-                                                    "",
-                                                    1,
-                                                )
+                                        my_job.dagman_out = os.path.normpath(
+                                            my_job.dagman_out.replace(
+                                                (options.workflow_base_dir + os.sep),
+                                                "",
+                                                1,
                                             )
                                         )
                                         # Join with current options.input_dir
@@ -983,9 +980,11 @@ class AnalyzeFiles(BaseAnalyze):
         # Try to parse workflow parameters from braindump.txt file
         wfparams = utils.slurp_braindb(self.options.input_dir)
         if "submit_dir" in wfparams:
-            self.options.workflow_base_dir = str(Path(wfparams["submit_dir"]))
+            self.options.workflow_base_dir = os.path.normpath(wfparams["submit_dir"])
         elif "jsd" in wfparams:
-            self.options.workflow_base_dir = str(Path(wfparams["jsd"]).parent)
+            self.options.workflow_base_dir = str(
+                Path(os.path.normpath(wfparams["jsd"])).parent
+            )
 
         # First we learn about jobs by going through the dag file
         self.parse_dag_file(dag_path)

--- a/packages/pegasus-common/src/Pegasus/client/analyzer.py
+++ b/packages/pegasus-common/src/Pegasus/client/analyzer.py
@@ -18,6 +18,7 @@ import tempfile
 import typing
 from dataclasses import asdict, dataclass, field
 from enum import Enum
+from pathlib import Path
 
 from Pegasus.db import connection
 from Pegasus.db.admin.admin_loader import DBAdminError
@@ -82,7 +83,7 @@ class AnalyzerError(Exception):
 
 
 # --- global variables ----------------------------------------------------------------
-prog_base = os.path.split(sys.argv[0])[1].replace(".py", "")  # Name of this program
+prog_base = Path(sys.argv[0]).name.replace(".py", "")  # Name of this program
 dag_path = None  # Path of the dag fi
 indent = ""  # the corresponding indent string
 
@@ -406,17 +407,17 @@ class BaseAnalyze:
         full_path = options.input_dir
         if my_job.sub_file == "":
             # Create full path for the submit file if we already don't have the sub file set up
-            my_job.sub_file = os.path.join(options.input_dir, my_job.name + ".sub")
+            my_job.sub_file = str(Path(options.input_dir) / f"{my_job.name}.sub")
         else:
-            full_path = os.path.dirname(my_job.sub_file)
-        my_job.out_file = os.path.join(full_path, my_job.name + ".out")
-        my_job.err_file = os.path.join(full_path, my_job.name + ".err")
+            full_path = str(Path(my_job.sub_file).parent)
+        my_job.out_file = str(Path(full_path) / f"{my_job.name}.out")
+        my_job.err_file = str(Path(full_path) / f"{my_job.name}.err")
 
         # Try to access submit file
         if os.access(my_job.sub_file, os.R_OK):
             # Open submit file
             try:
-                SUB = open(my_job.sub_file)
+                SUB = Path(my_job.sub_file).open()
             except Exception:
                 # print "error opening submit file: %s" % (my_job.sub_file)
                 raise AnalyzerError(f"error opening submit file: {my_job.sub_file}")
@@ -468,9 +469,7 @@ class BaseAnalyze:
                             if sub_prop:
                                 if sub_prop.group(1) == "_CONDOR_DAGMAN_LOG":
                                     my_job.dagman_out = sub_prop.group(2)
-                                    my_job.dagman_out = os.path.normpath(
-                                        my_job.dagman_out
-                                    )
+                                    my_job.dagman_out = str(Path(my_job.dagman_out))
                                     if (
                                         my_job.dagman_out.find(
                                             options.workflow_base_dir
@@ -478,28 +477,31 @@ class BaseAnalyze:
                                         >= 0
                                     ):
                                         # Path to dagman_out file includes original submit_dir, let's try to change it
-                                        my_job.dagman_out = os.path.normpath(
-                                            my_job.dagman_out.replace(
-                                                (options.workflow_base_dir + os.sep),
-                                                "",
-                                                1,
+                                        my_job.dagman_out = str(
+                                            Path(
+                                                my_job.dagman_out.replace(
+                                                    (
+                                                        options.workflow_base_dir
+                                                        + os.sep
+                                                    ),
+                                                    "",
+                                                    1,
+                                                )
                                             )
                                         )
                                         # Join with current options.input_dir
-                                        my_job.dagman_out = os.path.join(
-                                            options.input_dir, my_job.dagman_out
+                                        my_job.dagman_out = str(
+                                            Path(options.input_dir) / my_job.dagman_out
                                         )
 
                                         # Now, figure out the correct directory, accounting for
                                         # replanning and rescue modes
 
                                         # Split filename into dir and base names
-                                        my_dagman_dir = os.path.dirname(
-                                            my_job.dagman_out
+                                        my_dagman_dir = str(
+                                            Path(my_job.dagman_out).parent
                                         )
-                                        my_dagman_file = os.path.basename(
-                                            my_job.dagman_out
-                                        )
+                                        my_dagman_file = Path(my_job.dagman_out).name
                                         my_retry = my_job.retries
                                         if my_retry is None:
                                             logger.warning(
@@ -511,12 +513,12 @@ class BaseAnalyze:
                                             my_dagman_dir + f".{my_retry:03d}"
                                         )
                                         # If directory doesn't exist, let's change to rescue mode
-                                        if not os.path.isdir(my_retry_dir):
+                                        if not Path(my_retry_dir).is_dir():
                                             logger.debug(
                                                 f"sub-workflow directory {my_retry_dir} does not exist, shifting to rescue mode..."
                                             )
                                             my_retry_dir = my_dagman_dir + ".000"
-                                            if not os.path.isdir(my_retry_dir):
+                                            if not Path(my_retry_dir).is_dir():
                                                 # Still not able to find it, output warning message
                                                 logger.warning(
                                                     f"sub-workflow directory {my_retry_dir} does not exist!"
@@ -524,8 +526,8 @@ class BaseAnalyze:
                                                 continue
 
                                         # Found sub-workflow directory, let's compose the final path to the new dagman.out file...
-                                        my_job.dagman_out = os.path.join(
-                                            my_retry_dir, my_dagman_file
+                                        my_job.dagman_out = str(
+                                            Path(my_retry_dir) / my_dagman_file
                                         )
 
                     # Only parse following keys if we are running in strict mode
@@ -549,8 +551,8 @@ class BaseAnalyze:
                             v = BaseAnalyze.re_collapse_condor_subs.sub("", v)
 
                             # Make sure we have an absolute path
-                            if not os.path.isabs(v):
-                                v = os.path.join(options.input_dir, v)
+                            if not Path(v).is_absolute():
+                                v = str(Path(options.input_dir) / v)
 
                             # Done! Replace out/err filenames with what we have
                             if k == "output":
@@ -572,8 +574,8 @@ class BaseAnalyze:
             SUB.close()
             # If initialdir was specified, we need to make both error and output files relative to that
             if len(my_job.initial_dir):
-                my_job.out_file = os.path.join(my_job.initial_dir, my_job.out_file)
-                my_job.err_file = os.path.join(my_job.initial_dir, my_job.err_file)
+                my_job.out_file = str(Path(my_job.initial_dir) / my_job.out_file)
+                my_job.err_file = str(Path(my_job.initial_dir) / my_job.err_file)
         else:
             # Was not able to access submit file
             # fail silently for now...
@@ -933,14 +935,14 @@ class AnalyzeFiles(BaseAnalyze):
                 # If self.options.output_dir is specified, invoke monitord with that path
                 self.invoke_monitord(f"{dag_path}.dagman.out", self.options.output_dir)
                 # jobstate.log file uses wf_uuid as prefix
-                jsdl_path = os.path.join(
-                    self.options.output_dir,
-                    self.get_jsdl_filename(self.options.input_dir),
+                jsdl_path = str(
+                    Path(self.options.output_dir)
+                    / self.get_jsdl_filename(self.options.input_dir)
                 )
             else:
                 if run_directory_writable:
                     # Run directory is writable, write monitord output to jobstate.log file
-                    jsdl_path = os.path.join(self.options.input_dir, self.jsdl_filename)
+                    jsdl_path = str(Path(self.options.input_dir) / self.jsdl_filename)
                     # Invoke monitord
                     self.invoke_monitord(f"{dag_path}.dagman.out", None)
                 else:
@@ -954,21 +956,21 @@ class AnalyzeFiles(BaseAnalyze):
         else:
             if self.options.output_dir is not None:
                 # jobstate.log file uses wf_uuid as prefix and is inside self.options.output_dir
-                jsdl_path = os.path.join(
-                    self.options.output_dir,
-                    self.get_jsdl_filename(self.options.input_dir),
+                jsdl_path = str(
+                    Path(self.options.output_dir)
+                    / self.get_jsdl_filename(self.options.input_dir)
                 )
             else:
-                jsdl_path = os.path.join(self.options.input_dir, self.jsdl_filename)
+                jsdl_path = str(Path(self.options.input_dir) / self.jsdl_filename)
 
         # Compare timestamps of jsdl_path with dagman_out_path
         try:
-            jsdl_stat = os.stat(jsdl_path)
+            jsdl_stat = Path(jsdl_path).stat()
         except Exception:
             raise AnalyzerError("could not access " + jsdl_path + ", exiting...")
 
         try:
-            dagman_out_stat = os.stat(dagman_out_path)
+            dagman_out_stat = Path(dagman_out_path).stat()
         except Exception:
             raise AnalyzerError("could not access " + dagman_out_path + ", exiting...")
 
@@ -981,11 +983,9 @@ class AnalyzeFiles(BaseAnalyze):
         # Try to parse workflow parameters from braindump.txt file
         wfparams = utils.slurp_braindb(self.options.input_dir)
         if "submit_dir" in wfparams:
-            self.options.workflow_base_dir = os.path.normpath(wfparams["submit_dir"])
+            self.options.workflow_base_dir = str(Path(wfparams["submit_dir"]))
         elif "jsd" in wfparams:
-            self.options.workflow_base_dir = os.path.dirname(
-                os.path.normpath(wfparams["jsd"])
-            )
+            self.options.workflow_base_dir = str(Path(wfparams["jsd"]).parent)
 
         # First we learn about jobs by going through the dag file
         self.parse_dag_file(dag_path)
@@ -1077,13 +1077,13 @@ class AnalyzeFiles(BaseAnalyze):
         the function will return the first file matching the type.
         """
         try:
-            file_list = os.listdir(input_dir)
+            file_list = list(Path(input_dir).iterdir())
         except Exception:
             raise AnalyzerError("cannot read directory: " + input_dir)
 
         for file in file_list:
-            if file.endswith(file_type):
-                return os.path.join(input_dir, file)
+            if file.name.endswith(file_type):
+                return str(file)
 
         raise AnalyzerError(f"could not find any {file_type} file in {input_dir}")
 
@@ -1124,7 +1124,7 @@ class AnalyzeFiles(BaseAnalyze):
         """
         # Open dag file
         try:
-            DAG = open(dag_fn)
+            DAG = Path(dag_fn).open()
         except Exception:
             raise AnalyzerError(f"could not open dag file {dag_fn}: exiting...")
 
@@ -1149,8 +1149,8 @@ class AnalyzeFiles(BaseAnalyze):
                 if not self.has_seen(my_job[1]):
                     self.add_job(my_job[1], "UNSUBMITTED")
                     # Get submit file information from dag file
-                    self.jobs[my_job[1]].sub_file = os.path.join(
-                        self.options.input_dir, my_job[2]
+                    self.jobs[my_job[1]].sub_file = str(
+                        Path(self.options.input_dir) / my_job[2]
                     )
                     if my_job[1].startswith("pegasus-plan") or my_job[1].startswith(
                         "subdax_"
@@ -1210,7 +1210,7 @@ class AnalyzeFiles(BaseAnalyze):
         """This function parses the jobstate.log file, loading all job information."""
         # Open log file
         try:
-            JSDL = open(jobstate_fn)
+            JSDL = Path(jobstate_fn).open()
         except Exception:
             raise AnalyzerError(f"could not open file {jobstate_fn}: exiting...")
 
@@ -1395,7 +1395,7 @@ class AnalyzeFiles(BaseAnalyze):
         data = ""
         if file is not None:
             try:
-                with open(file) as file:
+                with Path(file).open() as file:
                     data = file.read().rstrip()
             except Exception:
                 logger.warning(f"*** Cannot access: {file}")
@@ -1414,7 +1414,7 @@ class DebugWF(BaseAnalyze):
         if not self.options.debug_job.endswith(".sub"):
             self.options.debug_job = self.options.debug_job + ".sub"
         # Figure out job name
-        jobname = os.path.basename(self.options.debug_job)
+        jobname = Path(self.options.debug_job).name
         jobname = jobname[0 : jobname.find(".sub")]
         # Create job class
         my_job = Job(jobname)
@@ -1435,11 +1435,11 @@ class DebugWF(BaseAnalyze):
 
         else:
             # Make sure directory specified is writable
-            self.options.debug_dir = os.path.abspath(self.options.debug_dir)
+            self.options.debug_dir = str(Path(self.options.debug_dir).resolve())
             if not os.access(self.options.debug_dir, os.F_OK):
                 # Create directory if it does not exist
                 try:
-                    os.mkdir(self.options.debug_dir)
+                    Path(self.options.debug_dir).mkdir()
                 except Exception:
                     logger.error(
                         f"cannot create debug directory: {self.options.debug_dir}"
@@ -1481,10 +1481,10 @@ class DebugWF(BaseAnalyze):
         # Create script name
         debug_script_basename = "debug_" + my_job.name + ".sh"
         debug_script_err_basename = "debug_" + my_job.name + ".err"
-        debug_script_name = os.path.join(self.options.debug_dir, debug_script_basename)
+        debug_script_name = str(Path(self.options.debug_dir) / debug_script_basename)
 
         try:
-            debug_script = open(debug_script_name, "w")
+            debug_script = Path(debug_script_name).open("w")
         except Exception:
             raise AnalyzerError(f"cannot create debug script {debug_script}")
 
@@ -1533,7 +1533,7 @@ class DebugWF(BaseAnalyze):
                     ):
                         # Add the initial dir to all files to be copied
                         # as long as they dont start with / or ${wf_submit_dir}
-                        my_file = os.path.join(my_job.initial_dir, my_file)
+                        my_file = str(Path(my_job.initial_dir) / my_file)
                     debug_script.write(f"cp {my_file} {self.options.debug_dir}\n")
 
             # Extra newline before executing the job
@@ -1548,7 +1548,7 @@ class DebugWF(BaseAnalyze):
                 # older non pegasus lite mode /sipht case?
                 debug_script.write("# Set the execute bit on the executable\n")
                 debug_script.write(
-                    f"chmod +x {os.path.join(self.options.debug_dir, my_job.executable)}\n"
+                    f"chmod +x {str(Path(self.options.debug_dir) / my_job.executable)}\n"
                 )
                 debug_script.write("\n")
             else:
@@ -1559,7 +1559,7 @@ class DebugWF(BaseAnalyze):
                 job_executable = debug_wrapper
 
             job_executable = (
-                os.path.join(self.options.debug_dir, job_executable) + my_job.arguments
+                str(Path(self.options.debug_dir) / job_executable) + my_job.arguments
             )
 
             debug_script.write(f'echo "executing job: {job_executable}"\n')
@@ -1573,7 +1573,7 @@ class DebugWF(BaseAnalyze):
             if job_pegasus_lite_wrapper is not None:
                 debug_script.write(
                     " 2> "
-                    + os.path.join(self.options.debug_dir, debug_script_err_basename)
+                    + str(Path(self.options.debug_dir) / debug_script_err_basename)
                 )
 
             debug_script.write("\n\n")
@@ -1619,7 +1619,7 @@ class DebugWF(BaseAnalyze):
 
         try:
             # Make our debug script executable
-            os.chmod(debug_script_name, 0o755)
+            Path(debug_script_name).chmod(0o755)
         except Exception:
             raise AnalyzerError(
                 f"cannot change permissions for the debug script {debug_script}"
@@ -1645,18 +1645,16 @@ class DebugWF(BaseAnalyze):
 
         if my_job.sub_file == "":
             # Create full path for the submit file if we already don't have the sub file set up
-            my_job.sub_file = os.path.join(self.options.input_dir, my_job.name + ".sub")
+            my_job.sub_file = str(Path(self.options.input_dir) / (my_job.name + ".sub"))
 
         # Create full path for the pegasus_lite_wrapped job on basis of where submit file is
-        pegasus_lite_wrapper = os.path.join(
-            os.path.dirname(my_job.sub_file), my_job.name + ".sh"
-        )
+        pegasus_lite_wrapper = str(Path(my_job.sub_file).parent / (my_job.name + ".sh"))
 
         # Try to access submit file
         if os.access(pegasus_lite_wrapper, os.R_OK):
             # Open submit file
             try:
-                SUB = open(pegasus_lite_wrapper)
+                SUB = Path(pegasus_lite_wrapper).open()
             except Exception:
                 # print "error opening submit file: %s" % (my_job.sub_file)
                 raise AnalyzerError("error opening submit file: " + my_job.sub_file)
@@ -1673,13 +1671,13 @@ class DebugWF(BaseAnalyze):
         if pegasus_lite_wrapper is None:
             return None
 
-        debug_wrapper = os.path.join(
-            self.options.debug_dir,
-            "stripped_pl_" + os.path.basename(pegasus_lite_wrapper),
+        debug_wrapper = str(
+            Path(self.options.debug_dir)
+            / ("stripped_pl_" + Path(pegasus_lite_wrapper).name)
         )
         try:
-            DEBUG_WRAPPER = open(debug_wrapper, "w")
-            WRAPPER = open(pegasus_lite_wrapper)
+            DEBUG_WRAPPER = Path(debug_wrapper).open("w")
+            WRAPPER = Path(pegasus_lite_wrapper).open()
             for line in WRAPPER:
                 if line.startswith("# stage out"):
                     # we only continue till we hit the stage out part
@@ -1717,6 +1715,6 @@ class DebugWF(BaseAnalyze):
                 WRAPPER.close()
 
         # set the x bit
-        os.chmod(debug_wrapper, 0o755)
+        Path(debug_wrapper).chmod(0o755)
 
         return debug_wrapper

--- a/packages/pegasus-common/src/Pegasus/client/status.py
+++ b/packages/pegasus-common/src/Pegasus/client/status.py
@@ -419,7 +419,7 @@ class Status:
             # if the directory is a sub-workflow directory
             else:
                 dag_dict = wf_name
-                submit = os.path.relpath(os.path.dirname(dagman_file), submit_dir)
+                submit = str(Path(dagman_file).parent.relative_to(submit_dir))
                 if self.show_dirs:
                     dag_name = f"{submit}/{wf_name}.dag"
                 else:
@@ -491,7 +491,7 @@ class Status:
         :type dag_dict: str
         """
         # parsing the dagman.out file
-        with open(dagman_file) as f:
+        with Path(dagman_file).open() as f:
             for line in f:
                 dag_status_line = re.match(
                     r"\d\d/\d\d/\d\d\ \d\d:\d\d:\d\d DAG status", line
@@ -577,7 +577,7 @@ class Status:
         ):
             for file in files:
                 if file.endswith(".dag.dagman.out"):
-                    dagmans.append(os.path.join(root, file))
+                    dagmans.append(str(Path(root) / file))
 
         return dagmans
 
@@ -743,7 +743,7 @@ class Status:
 
         new_path_dict = nested_dict()
         for path in paths:
-            parts = path.split("/")
+            parts = (str(Path(path).parent), Path(path).name)
             if parts:
                 sub_dict = new_path_dict
                 for key in parts[:]:

--- a/packages/pegasus-common/src/Pegasus/json.py
+++ b/packages/pegasus-common/src/Pegasus/json.py
@@ -26,7 +26,7 @@ class _CustomJSONEncoder(_json.JSONEncoder):
     """JSON encoder extended with Pegasus-specific type handling.
 
     Supports serialization of :class:`uuid.UUID`, :class:`enum.Enum`,
-    :class:`pathlib.Path`, SQLAlchemy model instances, and objects that
+    :class:`Path`, SQLAlchemy model instances, and objects that
     implement ``__html__()``, ``__json__()``, or ``__table__`` (SQLAlchemy).
     """
 

--- a/packages/pegasus-common/src/Pegasus/yaml.py
+++ b/packages/pegasus-common/src/Pegasus/yaml.py
@@ -59,13 +59,13 @@ _Loader.add_constructor(
 
 # Dumper extras
 def _represent_path(self, data: Path):
-    """Serialize a :class:`pathlib.Path` object to a YAML string scalar.
+    """Serialize a :class:`Path` object to a YAML string scalar.
 
     .. warning::
         ``Path("./aaa")`` serializes to ``"aaa"`` because ``str(Path("./aaa")) == "aaa"``.
 
     :param data: path object to serialize
-    :type data: pathlib.Path
+    :type data: Path
     """
     return self.represent_scalar("tag:yaml.org,2002:str", str(data))
 
@@ -111,7 +111,7 @@ dump = partial(_yaml.dump, Dumper=_Dumper)
 def dumps(obj: dict, Dumper=_Dumper, *args, **kwargs) -> str:
     """Serialize ``obj`` to a YAML formatted ``str``.
 
-    :class:`pathlib.Path` objects are serialized as strings and
+    :class:`Path` objects are serialized as strings and
     :class:`collections.OrderedDict` instances preserve their key order.
 
     :param obj: object to serialize

--- a/packages/pegasus-common/test/client/test_analyzer.py
+++ b/packages/pegasus-common/test/client/test_analyzer.py
@@ -1,15 +1,15 @@
-import os
 import sys
 import tempfile
+from pathlib import Path
 
 import pytest
 
 from Pegasus.client.analyzer import *
 from Pegasus.db import *
 
-directory = os.path.dirname(__file__)
+directory = str(Path(__file__).parent)
 pegasus_version = "5.0.1"
-prog_base = os.path.split(sys.argv[0])[1].replace(".py", "")
+prog_base = Path(sys.argv[0]).name.replace(".py", "")
 
 
 @pytest.fixture
@@ -71,9 +71,9 @@ class TestBaseAnalyze:
         )
 
     def test_parse_submit_file(self, mocker, capsys, BaseAnalyzer):
-        submit_file = os.path.join(
-            directory,
-            "analyzer_samples_dir/sample_wf_held/Drug-Combination-Therapy-0.dag.condor.sub",
+        submit_file = str(
+            Path(directory)
+            / "analyzer_samples_dir/sample_wf_held/Drug-Combination-Therapy-0.dag.condor.sub"
         )
         job = Job("job-0", "running")
         job.is_subdax = True
@@ -88,13 +88,15 @@ class TestBaseAnalyze:
         assert job.transfer_input_files == "rrr"
 
     def test_parse_submit_file_open_error(self, mocker, capsys, BaseAnalyzer):
-        submit_file = os.path.join(
-            directory,
-            "analyzer_samples_dir/sample_wf_held/Drug-Combination-Therapy-0.dag.condor.sub",
+        submit_file = str(
+            Path(directory)
+            / "analyzer_samples_dir/sample_wf_held/Drug-Combination-Therapy-0.dag.condor.sub"
         )
         job = Job("job-0", "running")
         job.sub_file = submit_file
-        mocker.patch("builtins.open", side_effect=Exception("mocked error"))
+        mocker.patch(
+            "Pegasus.client.analyzer.Path.open", side_effect=Exception("mocked error")
+        )
         opts = Options(
             debug_mode=True,
             input_dir="pegasus/hierarchical-workflow/run0005",
@@ -102,7 +104,7 @@ class TestBaseAnalyze:
         )
         with pytest.raises(Exception) as err:
             BaseAnalyze.parse_submit_file(job, opts)
-        assert f"error opening submit file: {submit_file}" in str(err)
+        assert f"error opening submit file: {submit_file}" in str(err.value)
 
     def test_parse_submit_file_subdag_job(self, mocker, capsys, BaseAnalyzer):
         job = Job("job-0", "running")
@@ -116,9 +118,9 @@ class TestBaseAnalyze:
         assert BaseAnalyze.parse_submit_file(job, opts) is None
 
     def test_parse_submit_file_no_retries(self, mocker, capsys, BaseAnalyzer):
-        submit_file = os.path.join(
-            directory,
-            "analyzer_samples_dir/sample_wf_held/Drug-Combination-Therapy-0.dag.condor.sub",
+        submit_file = str(
+            Path(directory)
+            / "analyzer_samples_dir/sample_wf_held/Drug-Combination-Therapy-0.dag.condor.sub"
         )
         job = Job("job-0", "running")
         job.is_subdax = True
@@ -140,8 +142,8 @@ class TestBaseAnalyze:
 class TestAnalyzerOutput:
     @pytest.fixture
     def get_output(self):
-        submit_dir = os.path.join(
-            directory, "analyzer_samples_dir/hierarchical_wf_failure"
+        submit_dir = str(
+            Path(directory) / "analyzer_samples_dir/hierarchical_wf_failure"
         )
         az = AnalyzeDB(Options(input_dir=submit_dir, traverse_all=True))
         out = az.analyze_db(None)
@@ -157,7 +159,7 @@ class TestAnalyzerOutput:
         assert analyzer_output.get_failed_workflows()["wf-0"].wf_status == "failure"
 
     def test_get_all_jobs(self, Output):
-        submit_dir = os.path.join(directory, "analyzer_samples_dir/sample_wf_held")
+        submit_dir = str(Path(directory) / "analyzer_samples_dir/sample_wf_held")
         az = AnalyzeDB(Options(input_dir=submit_dir))
         out = az.analyze_db(None)
         analyzer_output = Output()
@@ -182,7 +184,7 @@ class TestAnalyzerOutput:
         assert "pegasus-plan_diamond_subworkflow" in failed_jobs
 
     def test_get_held_jobs(self, Output):
-        submit_dir = os.path.join(directory, "analyzer_samples_dir/sample_wf_held")
+        submit_dir = str(Path(directory) / "analyzer_samples_dir/sample_wf_held")
         az = AnalyzeDB(Options(input_dir=submit_dir))
         out = az.analyze_db(None)
         analyzer_output = Output()
@@ -200,7 +202,7 @@ class TestAnalyzeDB:
         mocker.patch(
             "Pegasus.db.connection.url_by_submitdir", side_effect=AnalyzerError
         )
-        submit_dir = os.path.join(directory, "analyzer_samples_dir/process_wf_success")
+        submit_dir = str(Path(directory) / "analyzer_samples_dir/process_wf_success")
         analyze = AnalyzerDatabase(Options(input_dir=submit_dir))
 
         with pytest.raises(AnalyzerError) as err:
@@ -209,7 +211,7 @@ class TestAnalyzeDB:
 
     def test_analyze_db_no_url(self, mocker, capsys, AnalyzerDatabase):
         mocker.patch("Pegasus.db.connection.url_by_submitdir", return_value=None)
-        submit_dir = os.path.join(directory, "analyzer_samples_dir/process_wf_success")
+        submit_dir = str(Path(directory) / "analyzer_samples_dir/process_wf_success")
         analyze = AnalyzerDatabase(Options(input_dir=submit_dir))
 
         with pytest.raises(ValueError) as err:
@@ -220,7 +222,7 @@ class TestAnalyzeDB:
         mocker.patch(
             "Pegasus.db.workflow.stampede_statistics.StampedeStatistics.get_workflow_details"
         )
-        submit_dir = os.path.join(directory, "analyzer_samples_dir/process_wf_success")
+        submit_dir = str(Path(directory) / "analyzer_samples_dir/process_wf_success")
 
         analyze = AnalyzerDatabase(Options(input_dir=submit_dir))
         with pytest.raises(KeyError):
@@ -231,7 +233,7 @@ class TestAnalyzeDB:
         assert expected_error in captured_error
 
     def test_simple_wf_success(self, mocker, capsys, AnalyzerDatabase):
-        submit_dir = os.path.join(directory, "analyzer_samples_dir/process_wf_success")
+        submit_dir = str(Path(directory) / "analyzer_samples_dir/process_wf_success")
         analyze = AnalyzerDatabase(Options(input_dir=submit_dir))
         analyzer_ouput = analyze.analyze_db(None)
 
@@ -265,7 +267,7 @@ class TestAnalyzeDB:
         assert analyzer_ouput.as_dict() == expected_output
 
     def test_simple_wf_failure(self, mocker, capsys, AnalyzerDatabase):
-        submit_dir = os.path.join(directory, "analyzer_samples_dir/process_wf_failure")
+        submit_dir = str(Path(directory) / "analyzer_samples_dir/process_wf_failure")
         analyze = AnalyzerDatabase(Options(input_dir=submit_dir))
         analyzer_ouput = analyze.analyze_db(None)
 
@@ -330,7 +332,7 @@ class TestAnalyzeDB:
         assert analyzer_ouput.as_dict() == expected_output
 
     def test_sample_wf_held(self, mocker, capsys, AnalyzerDatabase):
-        submit_dir = os.path.join(directory, "analyzer_samples_dir/sample_wf_held")
+        submit_dir = str(Path(directory) / "analyzer_samples_dir/sample_wf_held")
         analyze = AnalyzerDatabase(Options(input_dir=submit_dir))
         analyze = AnalyzerDatabase(Options(input_dir=submit_dir))
         analyzer_ouput = analyze.analyze_db(None)
@@ -351,8 +353,8 @@ class TestAnalyzeDB:
         )
 
     def test_hierarchical_wf_traverse_all(self, mocker, capsys, AnalyzerDatabase):
-        submit_dir = os.path.join(
-            directory, "analyzer_samples_dir/hierarchical_wf_success"
+        submit_dir = str(
+            Path(directory) / "analyzer_samples_dir/hierarchical_wf_success"
         )
 
         analyze = AnalyzerDatabase(Options(input_dir=submit_dir, traverse_all=True))
@@ -408,8 +410,8 @@ class TestAnalyzeDB:
         assert analyzer_ouput.as_dict() == expected_output
 
     def test_hierarchical_wf_failure(self, mocker, capsys, AnalyzerDatabase):
-        submit_dir = os.path.join(
-            directory, "analyzer_samples_dir/hierarchical_wf_failure"
+        submit_dir = str(
+            Path(directory) / "analyzer_samples_dir/hierarchical_wf_failure"
         )
         analyze = AnalyzerDatabase(Options(input_dir=submit_dir))
         analyzer_ouput = analyze.analyze_db(None)
@@ -493,8 +495,8 @@ class TestAnalyzeDB:
         AnalyzeDB.get_job_details.assert_called_once_with("job-instance-0", None)
 
     def test_json_mode(self, mocker, capsys, AnalyzerDatabase):
-        submit_dir = os.path.join(
-            directory, "analyzer_samples_dir/hierarchical_wf_success"
+        submit_dir = str(
+            Path(directory) / "analyzer_samples_dir/hierarchical_wf_success"
         )
         analyze = AnalyzerDatabase(Options(input_dir=submit_dir, json_mode=True))
         analyzer_ouput = analyze.analyze_db(None)
@@ -529,8 +531,8 @@ class TestAnalyzeDB:
         assert analyzer_ouput.as_dict() == expected_output
 
     def test_json_mode_traverse_subworkflows(self, mocker, capsys, AnalyzerDatabase):
-        submit_dir = os.path.join(
-            directory, "analyzer_samples_dir/hierarchical_wf_success"
+        submit_dir = str(
+            Path(directory) / "analyzer_samples_dir/hierarchical_wf_success"
         )
         analyze = AnalyzerDatabase(
             Options(input_dir=submit_dir, json_mode=True, traverse_all=True)
@@ -592,7 +594,7 @@ class TestAnalyzeFiles:
         assert AnalyzerFiles is not None
 
     def test_simple_wf_success(self, mocker, capsys, AnalyzerFiles):
-        submit_dir = os.path.join(directory, "analyzer_samples_dir/process_wf_success")
+        submit_dir = str(Path(directory) / "analyzer_samples_dir/process_wf_success")
         analyze = AnalyzerFiles(Options(input_dir=submit_dir))
         analyzer_ouput = analyze.analyze_files()
 
@@ -626,8 +628,8 @@ class TestAnalyzeFiles:
         assert analyzer_ouput.as_dict() == expected_output
 
     def test_hierarchical_wf_success(self, mocker, capsys, AnalyzerFiles):
-        submit_dir = os.path.join(
-            directory, "analyzer_samples_dir/hierarchical_wf_success"
+        submit_dir = str(
+            Path(directory) / "analyzer_samples_dir/hierarchical_wf_success"
         )
         analyze = AnalyzerFiles(Options(input_dir=submit_dir))
         analyzer_ouput = analyze.analyze_files()
@@ -642,7 +644,7 @@ class TestAnalyzeFiles:
         assert output_state == expected_state
 
     def test_simple_wf_failure(self, mocker, capsys, AnalyzerFiles):
-        submit_dir = os.path.join(directory, "analyzer_samples_dir/process_wf_failure")
+        submit_dir = str(Path(directory) / "analyzer_samples_dir/process_wf_failure")
         analyze = AnalyzerFiles(Options(input_dir=submit_dir))
         analyzer_ouput = analyze.analyze_files()
 
@@ -720,7 +722,7 @@ class TestAnalyzeFiles:
     def test_analyze_files_monitord_errors(
         self, mocker, capsys, AnalyzerFiles, out_dir, expected_output
     ):
-        submit_dir = os.path.join(directory, "analyzer_samples_dir/process_wf_failure")
+        submit_dir = str(Path(directory) / "analyzer_samples_dir/process_wf_failure")
         mocker.patch("Pegasus.client.analyzer.AnalyzeFiles.invoke_monitord")
         mocker.patch(
             "Pegasus.client.analyzer.AnalyzeFiles.get_jsdl_filename",
@@ -736,8 +738,8 @@ class TestAnalyzeFiles:
         assert expected_output in str(err)
 
     def test_hierarchical_wf_failure(self, mocker, capsys, AnalyzerFiles):
-        submit_dir = os.path.join(
-            directory, "analyzer_samples_dir/hierarchical_wf_failure"
+        submit_dir = str(
+            Path(directory) / "analyzer_samples_dir/hierarchical_wf_failure"
         )
         analyze = AnalyzerFiles(Options(input_dir=submit_dir))
         analyzer_ouput = analyze.analyze_files()
@@ -754,9 +756,9 @@ class TestAnalyzeFiles:
     def DISABLED_test_invoke_monitord(self, mocker, AnalyzerFiles):
         mocker.patch("Pegasus.client.analyzer.BaseAnalyze.backticks")
         temp_dir = tempfile.mkdtemp("sample_temp_dir")
-        dagman_out_file = os.path.join(
-            directory,
-            "analyzer_samples_dir/process_wf_failure/process-0.dag.dagman.out",
+        dagman_out_file = str(
+            Path(directory)
+            / "analyzer_samples_dir/process_wf_failure/process-0.dag.dagman.out"
         )
 
         cmd = (
@@ -785,19 +787,19 @@ class TestAnalyzeFiles:
 
     def test_find_file_not_found(self, mocker, AnalyzerFiles):
         analyze = AnalyzerFiles(Options())
-        submit_dir = os.path.join(directory, "analyzer_samples_dir/process_wf_failure")
+        submit_dir = str(Path(directory) / "analyzer_samples_dir/process_wf_failure")
         with pytest.raises(Exception) as err:
             analyze.find_file(submit_dir, ".pkl")
         assert f"could not find any .pkl file in {submit_dir}" == str(err.value)
         assert AnalyzerError == err.type
 
     def test_get_jsdl_filename(self, mocker, AnalyzerFiles):
-        input_dir = os.path.join(directory, "analyzer_samples_dir/process_wf_failure")
+        input_dir = str(Path(directory) / "analyzer_samples_dir/process_wf_failure")
         analyze = AnalyzerFiles(Options())
         assert "jobstate.log" in analyze.get_jsdl_filename(input_dir)
 
     def test_get_jsdl_filename_no_braindump(self, mocker, AnalyzerFiles):
-        input_dir = os.path.join(directory, "analyzer_samples_dir/process_wf_failure")
+        input_dir = str(Path(directory) / "analyzer_samples_dir/process_wf_failure")
         mocker.patch("Pegasus.tools.utils.slurp_braindb", side_effect=AnalyzerError)
         analyze = AnalyzerFiles(Options())
 
@@ -808,7 +810,7 @@ class TestAnalyzeFiles:
         assert AnalyzerError == err.type
 
     def test_get_jsdl_filename_no_wf_uuid(self, mocker, AnalyzerFiles):
-        input_dir = os.path.join(directory, "analyzer_samples_dir/process_wf_failure")
+        input_dir = str(Path(directory) / "analyzer_samples_dir/process_wf_failure")
         mocker.patch("Pegasus.tools.utils.slurp_braindb", return_value={"job": "a"})
         analyze = AnalyzerFiles(Options())
 
@@ -819,7 +821,7 @@ class TestAnalyzeFiles:
         assert AnalyzerError == err.type
 
     def test_parse_dag_file(self, mocker, capsys, AnalyzerFiles):
-        dag_file = os.path.join(directory, "analyzer_samples_dir/sample.dag")
+        dag_file = str(Path(directory) / "analyzer_samples_dir/sample.dag")
         analyze = AnalyzerFiles(Options(input_dir="/random/dir"))
         analyze.parse_dag_file(dag_file)
         captured = capsys.readouterr()
@@ -883,8 +885,8 @@ class TestAnalyzeFiles:
         assert "could not find job job-1" in captured_error
 
     def test_dump_file(self, mocker, capsys, AnalyzerFiles):
-        file_path = os.path.join(
-            directory, "analyzer_samples_dir/process_wf_success/braindump.yml"
+        file_path = str(
+            Path(directory) / "analyzer_samples_dir/process_wf_success/braindump.yml"
         )
         analyze = AnalyzerFiles(Options())
         data = analyze.dump_file(file_path)
@@ -903,8 +905,8 @@ class TestDebugWF:
         assert "cannot access job submit file: job-0.sub" in str(err)
 
     def test_debug_workflow_no_tempdir(self, mocker, AnalyzerDebug):
-        submit_dir = os.path.join(directory, "analyzer_samples_dir/process_wf_failure")
-        job = os.path.join(submit_dir, "00/00/ls_ID0000001.sub")
+        submit_dir = str(Path(directory) / "analyzer_samples_dir/process_wf_failure")
+        job = str(Path(submit_dir) / "00/00/ls_ID0000001.sub")
         debug = AnalyzerDebug(Options(debug_job=job))
         mocker.patch("tempfile.mkdtemp", side_effect=AnalyzerError)
 
@@ -912,11 +914,15 @@ class TestDebugWF:
             debug.debug_workflow()
         assert "could not create temporary directory!" in str(err)
 
-    def test_debug_workflow_create_debug_dir_fail(self, mocker, capsys, AnalyzerDebug):
-        submit_dir = os.path.join(directory, "analyzer_samples_dir/process_wf_failure")
-        job = os.path.join(submit_dir, "00/00/ls_ID0000001.sub")
-        debug = AnalyzerDebug(Options(debug_job=job, debug_dir="a.txt"))
-        mocker.patch("os.mkdir", side_effect=AnalyzerError)
+    def test_debug_workflow_create_debug_dir_fail(
+        self, mocker, capsys, tmp_path, AnalyzerDebug
+    ):
+        submit_dir = str(Path(directory) / "analyzer_samples_dir/process_wf_failure")
+        job = str(Path(submit_dir) / "00/00/ls_ID0000001.sub")
+        debug = AnalyzerDebug(
+            Options(debug_job=job, debug_dir=str(tmp_path / "missing-debug-dir"))
+        )
+        mocker.patch("Pegasus.client.analyzer.Path.mkdir", side_effect=AnalyzerError)
 
         with pytest.raises(AnalyzerError):
             debug.debug_workflow()
@@ -925,8 +931,8 @@ class TestDebugWF:
         assert "cannot create debug directory:" in captured_error
 
     def test_debug_workflow_wf_type(mocker, capsys, AnalyzerDebug):
-        submit_dir = os.path.join(directory, "analyzer_samples_dir/process_wf_failure")
-        job = os.path.join(submit_dir, "00/00/ls_ID0000001.sub")
+        submit_dir = str(Path(directory) / "analyzer_samples_dir/process_wf_failure")
+        job = str(Path(submit_dir) / "00/00/ls_ID0000001.sub")
         debug = AnalyzerDebug(
             Options(debug_job=job, workflow_type="OTHER", input_dir=submit_dir)
         )
@@ -936,8 +942,8 @@ class TestDebugWF:
         assert "workflow type OTHER not supported!" in str(err)
 
     def test_debug_mode_no_debug_dir(mocker, capsys, AnalyzerDebug):
-        submit_dir = os.path.join(directory, "analyzer_samples_dir/process_wf_failure")
-        job = os.path.join(submit_dir, "00/00/ls_ID0000001.sub")
+        submit_dir = str(Path(directory) / "analyzer_samples_dir/process_wf_failure")
+        job = str(Path(submit_dir) / "00/00/ls_ID0000001.sub")
         debug = AnalyzerDebug(
             Options(debug_job=job, workflow_type="CONDOR", input_dir=submit_dir)
         )
@@ -948,8 +954,8 @@ class TestDebugWF:
         assert "finished generating job debug script!" in captured_output
 
     def test_debug_mode_with_debug_dir(mocker, capsys, AnalyzerDebug):
-        submit_dir = os.path.join(directory, "analyzer_samples_dir/process_wf_failure")
-        job = os.path.join(submit_dir, "00/00/ls_ID0000001.sub")
+        submit_dir = str(Path(directory) / "analyzer_samples_dir/process_wf_failure")
+        job = str(Path(submit_dir) / "00/00/ls_ID0000001.sub")
         temp_dir = tempfile.mkdtemp("sample_temp_dir")
         debug = AnalyzerDebug(
             Options(debug_job=job, input_dir=submit_dir, debug_dir=temp_dir)

--- a/packages/pegasus-common/test/test_status.py
+++ b/packages/pegasus-common/test/test_status.py
@@ -1,5 +1,5 @@
-import os
 from collections import defaultdict
+from pathlib import Path
 from textwrap import dedent
 
 import pytest
@@ -7,7 +7,7 @@ import pytest
 import Pegasus
 from Pegasus.client.status import Status
 
-directory = os.path.dirname(__file__)
+directory = str(Path(__file__).parent)
 
 
 @pytest.fixture
@@ -293,7 +293,7 @@ def test_fetch_status_json(
 ):
     mocker.patch("Pegasus.client.status.Status.get_braindump")
     mocker.patch("Pegasus.client.status.Status.get_q_values", return_value=None)
-    submit_dir = os.path.join(directory, samples_dir)
+    submit_dir = str(Path(directory) / samples_dir)
     status.root_wf_name = pegasus_wf_name_from_bd
     assert status.fetch_status(submit_dir, json=True) == expected_dict
     status.get_q_values.assert_called_once_with()
@@ -402,7 +402,7 @@ def test_show_dag_progress(
     mocker.patch("Pegasus.client.status.Status.get_braindump")
     mocker.patch("Pegasus.client.status.Status.get_q_values", return_value=None)
     status.root_wf_name = wf_name_from_bd
-    submit_dir = os.path.join(directory, samples_dir)
+    submit_dir = str(Path(directory) / samples_dir)
     status.fetch_status(submit_dir)
     captured = capsys.readouterr()
     assert captured.out == expected_output
@@ -428,7 +428,7 @@ def test_show_dag_progress_with_legend(mocker, capsys, status):
     mocker.patch("Pegasus.client.status.Status.get_braindump")
     mocker.patch("Pegasus.client.status.Status.get_q_values", return_value=None)
     status.root_wf_name = wf_name_from_bd
-    submit_dir = os.path.join(directory, samples_dir)
+    submit_dir = str(Path(directory) / samples_dir)
     status.fetch_status(submit_dir, legend=True, long=True)
     captured = capsys.readouterr()
     assert captured.out == expected_output
@@ -521,7 +521,7 @@ def test_show_dag_progress_long(
     mocker.patch("Pegasus.client.status.Status.get_braindump")
     mocker.patch("Pegasus.client.status.Status.get_q_values", return_value=None)
     status.root_wf_name = wf_name_from_bd
-    submit_dir = os.path.join(directory, samples_dir)
+    submit_dir = str(Path(directory) / samples_dir)
     status.fetch_status(submit_dir, long=True, dirs=dirs_option)
     captured = capsys.readouterr()
     print(captured.out)
@@ -545,7 +545,7 @@ def test_show_dag_progress_just_started(mocker, capsys, status):
     mocker.patch("Pegasus.client.status.Status.get_braindump")
     mocker.patch("Pegasus.client.status.Status.get_q_values", return_value=None)
     status.root_wf_name = "sample_started"
-    submit_dir = os.path.join(directory, "status_sample_files/sample_started")
+    submit_dir = str(Path(directory) / "status_sample_files/sample_started")
     status.fetch_status(submit_dir, long=True)
     captured = capsys.readouterr()
     assert captured.out == expected_output
@@ -703,7 +703,7 @@ def q_hierarchical_values():
             "JobStatus": 2,
             "EnteredCurrentStatus": 0,
             "pegasus_wf_xformation": "condor::dagman",
-            "Iwd": os.path.join(directory, "status_sample_files/sample1"),
+            "Iwd": str(Path(directory) / "status_sample_files/sample1"),
             "pegasus_wf_dag_job_id": "job1",
             "pegasus_wf_uuid": "uuid-0",
             "pegasus_root_wf_uuid": "uuid-0",
@@ -799,7 +799,7 @@ def test_get_time(mocker, status):
 
 
 def test_valid_braindump_dir(mocker, status):
-    submit_dir = os.path.join(directory, "status_sample_files/sample1")
+    submit_dir = str(Path(directory) / "status_sample_files/sample1")
     status.get_braindump(submit_dir)
     assert status.root_wf_uuid == "d943d68b-ffc6-4154-8b82-9d8be4dbd683"
     assert status.root_wf_name == "Drug-Combination-Therapy-0"

--- a/packages/pegasus-mpi-cluster/test/file_forward.py
+++ b/packages/pegasus-mpi-cluster/test/file_forward.py
@@ -2,10 +2,11 @@
 
 import os
 import sys
+from pathlib import Path
 
 for fname in sys.argv[1:]:
-    dname = os.path.dirname(fname)
-    if not os.path.isdir(dname):
+    dname = str(Path(fname).parent)
+    if not Path(dname).is_dir():
         os.makedirs(dname)
     f = open(fname, "w")
     f.write("This is file %s\n" % fname)

--- a/packages/pegasus-python/pyproject.toml
+++ b/packages/pegasus-python/pyproject.toml
@@ -112,7 +112,7 @@ extend-select = [
     "TID", # flake8-tidy-imports
     "TC",  # flake8-type-checking
     # "ARG", # flake8-unused-arguments
-    # "PTH", # flake8-use-pathlib
+    "PTH", # flake8-use-pathlib
     "I",  # isort
     "UP", # pyupgrade
 ]

--- a/packages/pegasus-python/src/Pegasus/analyzer_report.py
+++ b/packages/pegasus-python/src/Pegasus/analyzer_report.py
@@ -378,9 +378,9 @@ def _subwf_files_dir(ji: analyzer.JobInstance) -> str:
 
 
 def _subwf_db_dir(options: analyzer.Options, ji: analyzer.JobInstance) -> str:
-    my_wfdir = str(Path(ji.subwf_dir))
+    my_wfdir = os.path.normpath(ji.subwf_dir)
     if my_wfdir.find(ji.submit_dir) >= 0:
-        my_wfdir = str(Path(my_wfdir.replace(ji.submit_dir + os.sep, "", 1)))
+        my_wfdir = os.path.normpath(my_wfdir.replace(ji.submit_dir + os.sep, "", 1))
         my_wfdir = str(Path(options.input_dir) / my_wfdir)
     return my_wfdir
 

--- a/packages/pegasus-python/src/Pegasus/analyzer_report.py
+++ b/packages/pegasus-python/src/Pegasus/analyzer_report.py
@@ -27,6 +27,7 @@ from Pegasus.client import analyzer
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+from pathlib import Path
 
 # Rich's default inline-code style is "bold cyan on black"; the black background
 # is invisible on dark terminals but a jarring box on light ones. Drop the
@@ -373,14 +374,14 @@ def _job_instance(
 
 
 def _subwf_files_dir(ji: analyzer.JobInstance) -> str:
-    return os.path.split(ji.subwf_dir)[0]
+    return str(Path(ji.subwf_dir).parent)
 
 
 def _subwf_db_dir(options: analyzer.Options, ji: analyzer.JobInstance) -> str:
-    my_wfdir = os.path.normpath(ji.subwf_dir)
+    my_wfdir = str(Path(ji.subwf_dir))
     if my_wfdir.find(ji.submit_dir) >= 0:
-        my_wfdir = os.path.normpath(my_wfdir.replace(ji.submit_dir + os.sep, "", 1))
-        my_wfdir = os.path.join(options.input_dir, my_wfdir)
+        my_wfdir = str(Path(my_wfdir.replace(ji.submit_dir + os.sep, "", 1)))
+        my_wfdir = str(Path(options.input_dir) / my_wfdir)
     return my_wfdir
 
 

--- a/packages/pegasus-python/src/Pegasus/cli/pegasus-analyzer.py
+++ b/packages/pegasus-python/src/Pegasus/cli/pegasus-analyzer.py
@@ -21,6 +21,8 @@ if peg_path:
         if p not in sys.path:
             sys.path.insert(0, p)
 
+from pathlib import Path
+
 import click
 
 from Pegasus import analyzer_report
@@ -269,7 +271,7 @@ def pegasus_analyzer(
             options.print_invocation = True
 
     if top_dir is not None:
-        options.top_dir = os.path.abspath(top_dir)
+        options.top_dir = Path(top_dir).resolve()
 
     if debug_job is not None:
         options.debug_job = debug_job
@@ -277,18 +279,18 @@ def pegasus_analyzer(
         options.debug_mode = True
 
     if dag_filename:
-        options.input_dir = os.path.abspath(os.path.split(dag_filename)[0])
+        options.input_dir = Path(str(Path(dag_filename).parent)).resolve()
         # Assume current directory if input dir is empty
         if input_dir is None:
-            options.input_dir = os.getcwd()
+            options.input_dir = Path.cwd()
     else:
         # Select directory where jobstate.log is located
         if input_dir:
-            options.input_dir = os.path.abspath(input_dir)
+            options.input_dir = Path(input_dir).resolve()
         elif submit_dir:
             options.input_dir = submit_dir
         else:
-            options.input_dir = os.getcwd()
+            options.input_dir = Path.cwd()
 
     if options.debug_mode == 1:
         # Enter debug mode if job name given

--- a/packages/pegasus-python/src/Pegasus/cli/pegasus-config.py
+++ b/packages/pegasus-python/src/Pegasus/cli/pegasus-config.py
@@ -4,8 +4,7 @@
 import argparse
 import os
 import sys
-from glob import glob
-from os.path import abspath, dirname, exists, join, normpath
+from pathlib import Path
 
 
 def _python_hash(**kw):
@@ -48,10 +47,10 @@ export CLASSPATH
 
 
 def _get_bin_dir(exe):
-    bin_dir = normpath(join(dirname(abspath(exe)), "bin"))
+    bin_dir = str(Path(str(Path(Path(Path(exe).resolve()).parent) / "bin")))
 
-    while not exists(bin_dir):
-        bin_dir = normpath(join(bin_dir, "..", "..", "bin"))
+    while not Path(bin_dir).exists():
+        bin_dir = str(Path(str(Path(bin_dir) / ".." / ".." / "bin")))
 
     return bin_dir
 
@@ -74,7 +73,7 @@ def _main(
     _version = "6.0.0-dev.0"
 
     bin_dir = _get_bin_dir(sys.argv[0])
-    base_dir = dirname(bin_dir)
+    base_dir = Path(bin_dir).parent
 
     lib = "@LIBDIR@"  # lib64 for 64bit RPMS
     if lib.startswith("@"):
@@ -84,24 +83,28 @@ def _main(
     if python_lib.startswith("@"):
         python_lib = "lib/pegasus/python"
 
-    conf_dir = join(base_dir, "etc")
-    share_dir = join(base_dir, "share", "pegasus")
-    java_dir = join(share_dir, "java")
-    python_dir = join(base_dir, python_lib)
-    python_externals_dir = join(base_dir, lib, "pegasus", "externals", "python")
-    schema_dir = join(share_dir, "schema")
-    r_dir = "".join(sorted(glob(join(share_dir, "r", "*.tar.gz"))))
+    conf_dir = str(Path(base_dir) / "etc")
+    share_dir = str(Path(base_dir) / "share" / "pegasus")
+    java_dir = str(Path(share_dir) / "java")
+    python_dir = str(Path(base_dir) / python_lib)
+    python_externals_dir = str(
+        Path(base_dir) / lib / "pegasus" / "externals" / "python"
+    )
+    schema_dir = str(Path(share_dir) / "schema")
+    r_dir = "".join(
+        str(path) for path in sorted((Path(share_dir) / "r").glob("*.tar.gz"))
+    )
 
     # for development - running out of a source checkout
-    test = join(base_dir, "build", "classes")
-    extra_classpath = test if exists(test) else ""
+    test = str(Path(base_dir) / "build" / "classes")
+    extra_classpath = test if Path(test).exists() else ""
 
     # in native packaging mode, some directories move
     if base_dir == "/usr":
         conf_dir = "/etc/pegasus"
 
     # classpath
-    jars = sorted(glob(join(java_dir, "*.jar")))
+    jars = [str(path) for path in sorted(Path(java_dir).glob("*.jar"))]
     if extra_classpath:
         jars.insert(0, extra_classpath)
 
@@ -110,7 +113,7 @@ def _main(
         _classpath += ":" + os.environ["CLASSPATH"]
 
     # construct aws batch classpath
-    aws_jars = sorted(glob(join(java_dir, "aws", "*.jar")))
+    aws_jars = [str(path) for path in sorted((Path(java_dir) / "aws").glob("*.jar"))]
     _classpath += ":" + ":".join(aws_jars)
 
     eol = "" if noeoln else "\n"

--- a/packages/pegasus-python/src/Pegasus/cli/pegasus-config.py
+++ b/packages/pegasus-python/src/Pegasus/cli/pegasus-config.py
@@ -47,10 +47,10 @@ export CLASSPATH
 
 
 def _get_bin_dir(exe):
-    bin_dir = str(Path(str(Path(Path(Path(exe).resolve()).parent) / "bin")))
+    bin_dir = os.path.normpath(Path(exe).resolve().parent / "bin")
 
     while not Path(bin_dir).exists():
-        bin_dir = str(Path(str(Path(bin_dir) / ".." / ".." / "bin")))
+        bin_dir = os.path.normpath(Path(bin_dir) / ".." / ".." / "bin")
 
     return bin_dir
 

--- a/packages/pegasus-python/src/Pegasus/cli/pegasus-cwl-converter.py
+++ b/packages/pegasus-python/src/Pegasus/cli/pegasus-cwl-converter.py
@@ -136,7 +136,7 @@ def get_name(parent_id: str, _id: str) -> str:
 
 def load_wf_inputs(input_spec_file_path: str) -> dict:
     try:
-        with open(input_spec_file_path) as f:
+        with Path(input_spec_file_path).open() as f:
             wf_inputs = yaml.load(f)
 
         log.info(f"Loaded workflow inputs file: {input_spec_file_path}")
@@ -165,7 +165,7 @@ def load_tr_specs(tr_specs_file_path: str) -> dict:
     }
 
     try:
-        with open(tr_specs_file_path) as f:
+        with Path(tr_specs_file_path).open() as f:
             specs = yaml.load(f)
 
         validate(instance=specs, schema=schema)

--- a/packages/pegasus-python/src/Pegasus/cli/pegasus-dagman.py
+++ b/packages/pegasus-python/src/Pegasus/cli/pegasus-dagman.py
@@ -44,20 +44,22 @@ if peg_path:
         if p not in sys.path:
             sys.path.insert(0, p)
 
+from pathlib import Path
+
 from Pegasus.tools import utils
 
 
 def find_prog(prog, dir=[]):
     def is_prog(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+        return Path(fpath).is_file() and os.access(fpath, os.X_OK)
 
-    fpath, fname = os.path.split(prog)
+    fpath = "" if Path(prog).parent == Path() else str(Path(prog).parent)
     if fpath:
         if is_prog(prog):
             return prog
     else:
         for path in dir + os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, prog)
+            exe_file = str(Path(path) / prog)
             if is_prog(exe_file):
                 return exe_file
     return None
@@ -117,7 +119,7 @@ def monitord_launch(monitord_bin, arguments=[]):
             logfile = "monitord.log"
             utils.rotate_log_file(logfile)
             # we have the right name of the log file
-            log = open(logfile, "a", 1)
+            log = Path(logfile).open("a", 1)
             monitord_proc = subprocess.Popen(
                 [monitord_bin, "-N", os.getenv("_CONDOR_DAGMAN_LOG")],
                 stdout=log.fileno(),
@@ -198,8 +200,8 @@ if __name__ == "__main__":
         # If copy_to_spool is set copy dagman binary to dag submit directory
         if copy_to_spool:
             old_dagman_bin = dagman_bin
-            dagman_bin = os.path.join(
-                os.getcwd(), "condor_scheduniv_exec." + os.getenv("CONDOR_ID")
+            dagman_bin = str(
+                Path.cwd() / ("condor_scheduniv_exec." + os.getenv("CONDOR_ID"))
             )
             shutil.copy2(old_dagman_bin, dagman_bin)
             logger.info(f"Copied condor_dagman from {old_dagman_bin} to {dagman_bin}")
@@ -280,5 +282,5 @@ if __name__ == "__main__":
     )
     if copy_to_spool:
         logger.info(f"Removing copied condor_dagman from submit directory {dagman_bin}")
-        os.remove(dagman_bin)
+        Path(dagman_bin).unlink()
     sys.exit(dagman.returncode & monitord.returncode)

--- a/packages/pegasus-python/src/Pegasus/cli/pegasus-graphviz.py
+++ b/packages/pegasus-python/src/Pegasus/cli/pegasus-graphviz.py
@@ -21,6 +21,7 @@ if peg_path:
         if p not in sys.path:
             sys.path.insert(0, p)
 
+
 from Pegasus import yaml
 
 COLORS = [
@@ -266,7 +267,7 @@ def parse_daxfile(fname, files=False):
     handler = DAXHandler(files)
     parser = xml.sax.make_parser()
     parser.setContentHandler(handler)
-    f = open(fname)
+    f = Path(fname).open()
     parser.parse(f)
     f.close()
     return handler.dag
@@ -279,7 +280,7 @@ def parse_xform_name(path):
     For special pegasus jobs (create_dir, etc.) set the name manually.
     """
     # Handle special cases
-    fname = os.path.basename(path)
+    fname = Path(path).name
     if fname.startswith("create_dir_"):
         return "pegasus::create_dir"
     if fname.startswith("stage_in_"):
@@ -296,8 +297,8 @@ def parse_xform_name(path):
         return "pegasus::clean_up"
 
     # Get it from the submit file
-    if os.path.isfile(path):
-        f = open(path)
+    if Path(path).is_file():
+        f = Path(path).open()
         for line in f.readlines():
             if "+pegasus_wf_xformation" in line:
                 return line.split('"')[1]
@@ -311,10 +312,10 @@ def parse_dagfile(fname):
     """
     Parse a DAG from a dagfile.
     """
-    dagdir = os.path.dirname(fname)
+    dagdir = Path(fname).parent
     dag = DAG()
     jobs = dag.nodes
-    f = open(fname)
+    f = Path(fname).open()
     for line in f.readlines():
         line = line.strip()
         if line.startswith("JOB"):
@@ -324,8 +325,8 @@ def parse_dagfile(fname):
                 raise Exception("Invalid line:", line)
             job.id = rec[1]  # Job id
             subfile = rec[2]  # submit script
-            if not os.path.isabs(subfile):
-                subfile = os.path.join(dagdir, subfile)
+            if not Path(subfile).is_absolute():
+                subfile = str(Path(dagdir) / subfile)
             job.xform = parse_xform_name(subfile)
             job.label = job.id
             jobs[job.id] = job
@@ -346,7 +347,7 @@ def parse_yamlfile(fname, include_files):
     """
     Parse a DAG from a YAML workflow file.
     """
-    with open(fname) as f:
+    with Path(fname).open() as f:
         wf = yaml.load(f)
 
     dag = DAG()
@@ -415,7 +416,7 @@ def dax_file_is_xml(fname):
     :return: boolean returning True if xml
     """
 
-    f = open(fname)
+    f = Path(fname).open()
     header = ""
     for line in f.readlines():
         header = line.strip()
@@ -557,7 +558,7 @@ class emit_dot:
         self.next_color = 0  # Keep track of next color
         self.colors = {}  # Keep track of transformation names to assign colors
 
-        self.out = open(outfile, "w")
+        self.out = Path(outfile).open("w")
         # Render the header
         self.out.write("digraph dag {\n")
         if width and height:

--- a/packages/pegasus-python/src/Pegasus/cli/pegasus-monitord.py
+++ b/packages/pegasus-python/src/Pegasus/cli/pegasus-monitord.py
@@ -44,6 +44,8 @@ if peg_path:
         if p not in sys.path:
             sys.path.insert(0, p)
 
+from pathlib import Path
+
 from Pegasus.db import connection
 from Pegasus.monitoring import event_output as eo
 from Pegasus.monitoring import notifications
@@ -51,7 +53,7 @@ from Pegasus.monitoring.workflow import MONITORD_RECOVER_FILE, Workflow
 from Pegasus.tools import properties, utils
 
 # Save our own basename
-prog_base = os.path.split(sys.argv[0])[1]
+prog_base = Path(sys.argv[0]).name
 
 
 utils.configureLogging()
@@ -171,7 +173,7 @@ def delete_pid_file():
     This function deletes the pid file when exiting.
     """
     try:
-        os.unlink(pid_filename)
+        Path(pid_filename).unlink()
     except OSError:
         logger.error(f"cannot delete pid file {pid_filename}")
 
@@ -421,11 +423,11 @@ if not out.endswith(".dagman.out"):
     sys.exit(1)
 
 # Turn into absolute filename
-out = os.path.abspath(out)
+out = Path(out).resolve()
 
 # Infer run directory
-run = os.path.dirname(out)
-if not os.path.isdir(run):
+run = Path(out).parent
+if not Path(run).is_dir():
     logger.critical(f"Run directory {run} does not exist")
     exit(1)
 os.chdir(run)
@@ -437,8 +439,8 @@ if "properties" in top_level_wf_params:
     top_level_prop_file = top_level_wf_params["properties"]
     # Create the full path by using the submit_dir key from braindump
     if "submit_dir" in top_level_wf_params:
-        top_level_prop_file = os.path.join(
-            top_level_wf_params["submit_dir"], top_level_prop_file
+        top_level_prop_file = str(
+            Path(top_level_wf_params["submit_dir"]) / top_level_prop_file
         )
 
 # Parse, and process properties
@@ -480,7 +482,7 @@ if options.skip_pid_check is not None:
     skip_pid_check = True
 
 # Make sure no other pegasus-monitord instances are running...
-pid_filename = os.path.join(run, "monitord.pid")
+pid_filename = str(Path(run) / "monitord.pid")
 if not skip_pid_check and utils.pid_running(pid_filename):
     logger.critical(
         "it appears that pegasus-monitord is still running on this workflow... exiting"
@@ -559,8 +561,8 @@ if options.skip_stdout is not None:
 if options.output_dir is not None:
     output_dir = options.output_dir
     try:
-        if not os.path.exists(output_dir):
-            os.makedirs(output_dir)
+        if not Path(output_dir).exists():
+            Path(output_dir).mkdir(parents=True)
     except OSError:
         logger.critical(f"cannot create directory {output_dir}. exiting...")
         sys.exit(1)
@@ -616,7 +618,7 @@ if encoding is None:
 # Check if the user-provided jsd file is an absolute path, if so, we
 # disable recursive mode
 if jsd is not None:
-    if os.path.isabs(jsd):
+    if Path(jsd).is_absolute():
         # Yes, this is an absolute path
         follow_subworkflows = False
         logger.warning(
@@ -985,7 +987,7 @@ def process_dagman_out(wf, log_line):
 
             # Make a symlink for NFS-secured files
             my_log, my_base = utils.out2log(wf._run_dir, wf._out_file)
-            if os.path.islink(my_log):
+            if Path(my_log).is_symlink():
                 logger.info(f"symlink {my_log} already exists")
             elif os.access(my_log, os.R_OK):
                 logger.info(f"{my_base} is a regular file, not touching")
@@ -996,11 +998,11 @@ def process_dagman_out(wf, log_line):
                 ):
                     if os.access(my_log, os.R_OK):
                         try:
-                            os.rename(my_log, f"{my_log}.bak")
+                            Path(my_log).rename(f"{my_log}.bak")
                         except OSError:
                             logger.warning(f"error renaming {my_log} to {my_log}.bak")
                     try:
-                        os.symlink(wf._condorlog, my_log)
+                        Path(my_log).symlink_to(wf._condorlog)
                     except OSError:
                         logger.info(f"unable to symlink {wf._condorlog}")
                     else:
@@ -1148,7 +1150,7 @@ signal.signal(signal.SIGUSR1, prog_sigusr1_handler)
 signal.signal(signal.SIGUSR2, prog_sigusr2_handler)
 
 # Log recover mode
-if os.access(os.path.join(run, MONITORD_RECOVER_FILE), os.F_OK):
+if os.access(str(Path(run) / MONITORD_RECOVER_FILE), os.F_OK):
     logger.warning(
         "monitord entering it's own recovery mode. Population will start again for the workflow.."
     )
@@ -1160,7 +1162,7 @@ if no_events:
     # generating bp file or database events
     dashboard_event_sink = None
 else:
-    if replay_mode or os.access(os.path.join(run, MONITORD_RECOVER_FILE), os.F_OK):
+    if replay_mode or os.access(str(Path(run) / MONITORD_RECOVER_FILE), os.F_OK):
         restart_logging = True
 
     # PM-652 if there is sqlite db then just take a backup
@@ -1243,11 +1245,11 @@ if fast_start_mode:
 
 # Build sub-workflow retry filename
 if output_dir is None:
-    wf_retry_fn = os.path.join(run, MONITORD_WF_RETRY_FILE)
+    wf_retry_fn = str(Path(run) / MONITORD_WF_RETRY_FILE)
     wf_notification_fn_prefix = run
 else:
-    wf_retry_fn = os.path.join(run, output_dir, MONITORD_WF_RETRY_FILE)
-    wf_notification_fn_prefix = os.path.join(run, output_dir)
+    wf_retry_fn = str(Path(run) / output_dir / MONITORD_WF_RETRY_FILE)
+    wf_notification_fn_prefix = str(Path(run) / output_dir)
 
 # Empty sub-workflow retry information if in replay mode
 # PM-704 in replay or restart logging case we always take a backup
@@ -1256,7 +1258,7 @@ else:
 # submit directory for the sub workflow
 if restart_logging:
     subworkflow_db_file = wf_retry_fn + ".db"
-    if os.path.isfile(subworkflow_db_file):
+    if Path(subworkflow_db_file).is_file():
         logger.info(f"Rotating sub workflow db file {subworkflow_db_file}")
         utils.rotate_log_file(subworkflow_db_file)
 
@@ -1328,7 +1330,7 @@ while len(wfs) > 0:
             # First, we test if the file is already there, in case we are running in replay mode
             if replay_mode:
                 try:
-                    f_stat = os.stat(workflow_entry.dagman_out)
+                    f_stat = Path(workflow_entry.dagman_out).stat()
                 except OSError:
                     logger.critical(
                         f"error: workflow not started, {workflow_entry.dagman_out} does not exist, dropping this workflow..."
@@ -1341,7 +1343,7 @@ while len(wfs) > 0:
                     continue
 
             try:
-                f_stat = os.stat(workflow_entry.dagman_out)
+                f_stat = Path(workflow_entry.dagman_out).stat()
             except OSError as e:
                 if errno.errorcode[e.errno] == "ENOENT":
                     # File doesn't exist yet, keep looking
@@ -1385,7 +1387,7 @@ while len(wfs) > 0:
             else:
                 # Found it, open dagman.out file
                 try:
-                    workflow_entry.DMOF = open(workflow_entry.dagman_out)
+                    workflow_entry.DMOF = Path(workflow_entry.dagman_out).open()
                     workflow_entry.dagman_out_appeared = True
                 except OSError:
                     logger.critical(f"opening {workflow_entry.dagman_out}")
@@ -1399,7 +1401,7 @@ while len(wfs) > 0:
         if workflow_entry.DMOF is not None:
             try:
                 logger.trace(f"stating file: {workflow_entry.dagman_out}")
-                f_stat = os.stat(workflow_entry.dagman_out)
+                f_stat = Path(workflow_entry.dagman_out).stat()
             except OSError:
                 # stat error
                 logger.critical(f"stat {workflow_entry.dagman_out}")
@@ -1534,10 +1536,10 @@ while len(wfs) > 0:
                             parent_jobseq = process_output[2]
                             # Only if we are not already tracking it...
                             tracking_already = False
-                            new_dagman_out = os.path.abspath(new_dagman_out)
+                            new_dagman_out = Path(new_dagman_out).resolve()
                             # Add the current run directory in case this is a relative path
-                            new_dagman_out = os.path.join(
-                                workflow_entry.run_dir, new_dagman_out
+                            new_dagman_out = str(
+                                Path(workflow_entry.run_dir) / new_dagman_out
                             )
                             if replay_mode:
                                 # Check if we started tracking this subworkflow in the past
@@ -1565,7 +1567,7 @@ while len(wfs) > 0:
                                     f"found new workflow to track: {new_dagman_out}"
                                 )
                                 # Not tracking this workflow, let's try to add it to our list
-                                new_run_dir = os.path.dirname(new_dagman_out)
+                                new_run_dir = Path(new_dagman_out).parent
                                 parent_wf_id = workflow_entry.wf._wf_uuid
                                 new_wf = Workflow(
                                     new_run_dir,
@@ -1598,17 +1600,15 @@ while len(wfs) > 0:
                             else:
                                 # Just make sure we link the workflow to its parent job,
                                 # which in this case is a job retry...
-                                if os.path.dirname(new_dagman_out) in Workflow.wf_list:
+                                if Path(new_dagman_out).parent in Workflow.wf_list:
                                     workflow_entry.wf.map_subwf(
                                         parent_jobid,
                                         parent_jobseq,
-                                        Workflow.wf_list[
-                                            os.path.dirname(new_dagman_out)
-                                        ],
+                                        Workflow.wf_list[Path(new_dagman_out).parent],
                                     )
                                 else:
                                     logger.warning(
-                                        f"cannot link job {parent_jobid}:{parent_jobseq} to its subwf because we don't have info for dir: {os.path.dirname(new_dagman_out)}"
+                                        f"cannot link job {parent_jobid}:{parent_jobseq} to its subwf because we don't have info for dir: {Path(new_dagman_out).parent}"
                                     )
 
                         if millisleep is not None:

--- a/packages/pegasus-python/src/Pegasus/cli/pegasus-remove.py
+++ b/packages/pegasus-python/src/Pegasus/cli/pegasus-remove.py
@@ -42,7 +42,7 @@ def pegasus_remove(ctx, dag_id=None, verbose=False, submit_dir=None):
         ctx.exit(1)
 
     if submit_dir:
-        cwd = os.getcwd()
+        cwd = Path.cwd()
 
         submit_dir = str(Path(submit_dir).resolve())
         try:
@@ -65,7 +65,7 @@ def pegasus_remove(ctx, dag_id=None, verbose=False, submit_dir=None):
         dag_log_file = config["dag"] + ".dagman.out"
         pattern = re.compile(r"\.([0-9\.]+) \(CONDOR_DAGMAN\) STARTING UP")
 
-        with open(dag_log_file) as fp:
+        with Path(dag_log_file).open() as fp:
             for line in fp.readlines():
                 match = pattern.search(line)
                 if match:

--- a/packages/pegasus-python/src/Pegasus/cli/pegasus-run.py
+++ b/packages/pegasus-python/src/Pegasus/cli/pegasus-run.py
@@ -203,7 +203,7 @@ def pegasus_run(ctx, grid=False, json=False, verbose=0, submit_dir=None):
     logging.basicConfig(level=logging.ERROR - (min(verbose, 3) * 10))
 
     os.umask(0o022)
-    cwd = os.getcwd()
+    cwd = Path.cwd()
     config = slurp_braindb(submit_dir)
     submit_dir = str(Path(submit_dir).resolve())
 
@@ -242,7 +242,7 @@ def pegasus_run(ctx, grid=False, json=False, verbose=0, submit_dir=None):
             halt_released = False
             if Path(config["dag"] + ".halt").exists():
                 click.echo("Found a previously halted workflow. Releasing it now.")
-                for halt_file in Path(".").rglob("*.dag.halt"):
+                for halt_file in Path().rglob("*.dag.halt"):
                     try:
                         halt_file.unlink()
                     except OSError:

--- a/packages/pegasus-python/src/Pegasus/cli/pegasus-status.py
+++ b/packages/pegasus-python/src/Pegasus/cli/pegasus-status.py
@@ -90,7 +90,7 @@ def get_wf_status(ctx, long, jsonrv, watch, dirs, legend, noqueue, debug, submit
     """pegasus-status helps to retrieve status of a given workflow."""
 
     if not submit_dir:
-        cwd = os.getcwd()
+        cwd = Path.cwd()
         if slurp_braindb(cwd):
             submit_dir = cwd
         else:

--- a/packages/pegasus-python/src/Pegasus/db/admin/admin_loader.py
+++ b/packages/pegasus-python/src/Pegasus/db/admin/admin_loader.py
@@ -22,6 +22,7 @@ import subprocess
 import sys
 import time
 import warnings
+from pathlib import Path
 
 from sqlalchemy import func, inspect, select
 from sqlalchemy.exc import OperationalError, ProgrammingError
@@ -118,13 +119,13 @@ def get_compatible_version(version):
 
         # PM-1596 - Python codes now get PEGASUS_HOME set correctly
         if "PEGASUS_HOME" in os.environ:
-            f = os.path.join(os.environ.get("PEGASUS_HOME"), "bin/pegasus-version")
-            if os.path.isfile(f):
+            f = str(Path(os.environ.get("PEGASUS_HOME")) / "bin/pegasus-version")
+            if Path(f).is_file():
                 pegasus_version = f
 
         if not pegasus_version:
-            f = os.path.join(os.path.dirname(sys.argv[0]), "pegasus-version")
-            if os.path.isfile(f):
+            f = str(Path(Path(sys.argv[0]).parent) / "pegasus-version")
+            if Path(f).is_file():
                 pegasus_version = f
 
         if pegasus_version:
@@ -133,7 +134,7 @@ def get_compatible_version(version):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 shell=True,
-                cwd=os.getcwd(),
+                cwd=Path.cwd(),
             )
             out, err = child.communicate()
             if child.returncode != 0:
@@ -357,8 +358,8 @@ def all_workflows_db(
     """
     # log files
     file_prefix = "{}-dbadmin".format(time.strftime("%Y%m%dT%H%M%S"))
-    f_out = open(f"{file_prefix}.out", "w")
-    f_err = open(f"{file_prefix}.err", "w")
+    f_out = Path(f"{file_prefix}.out").open("w")
+    f_err = Path(f"{file_prefix}.err").open("w")
 
     data = db.execute(
         select(

--- a/packages/pegasus-python/src/Pegasus/db/admin/versions/v12.py
+++ b/packages/pegasus-python/src/Pegasus/db/admin/versions/v12.py
@@ -14,8 +14,8 @@
 #  limitations under the License.
 #
 import logging
-import os
 import subprocess
+from pathlib import Path
 
 from sqlalchemy.sql import text
 
@@ -157,7 +157,7 @@ class Version(BaseVersion):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 shell=True,
-                cwd=os.getcwd(),
+                cwd=Path.cwd(),
             )
             out, err = child.communicate()
             if child.returncode != 0:

--- a/packages/pegasus-python/src/Pegasus/db/connection.py
+++ b/packages/pegasus-python/src/Pegasus/db/connection.py
@@ -19,6 +19,7 @@ import getpass
 import logging
 import os
 import subprocess
+from pathlib import Path
 from sqlite3 import Connection as SQLite3Connection
 from stat import ST_MODE
 from urllib.parse import urlparse
@@ -178,7 +179,7 @@ def connect(
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     shell=True,
-                    cwd=os.getcwd(),
+                    cwd=Path.cwd(),
                 ).communicate()
 
                 pids = out.decode("utf8").strip().replace(" ", ",")
@@ -187,7 +188,7 @@ def connect(
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     shell=True,
-                    cwd=os.getcwd(),
+                    cwd=Path.cwd(),
                 ).communicate()
                 if err:
                     raise ConnectionError(
@@ -313,8 +314,8 @@ def url_by_submitdir(
         top_level_prop_file = top_level_wf_params["properties"]
         # Create the full path by using the submit_dir key from braindump
         if "submit_dir" in top_level_wf_params:
-            top_level_prop_file = os.path.join(
-                top_level_wf_params["submit_dir"], top_level_prop_file
+            top_level_prop_file = str(
+                Path(top_level_wf_params["submit_dir"]) / top_level_prop_file
             )
 
     return url_by_properties(
@@ -467,7 +468,7 @@ def _get_jdbcrc_uri(props=None):
         if driver.lower() == "sqlite":
             if "sqlite:" in url:
                 return url
-            connString = os.path.join(host, "workflow.db")
+            connString = str(Path(host) / "workflow.db")
             return "sqlite:///" + connString
 
         if driver.lower() == "postgresql":
@@ -502,12 +503,12 @@ def _get_master_uri(props=None):
             f"Environment variable HOME not defined, set {PROP_DASHBOARD_OUTPUT} property to point to the Dashboard database."
         )
 
-    dir = os.path.join(homedir, ".pegasus")
+    dir = str(Path(homedir) / ".pegasus")
 
     # check for writability and create directory if required
-    if not os.path.isdir(dir):
+    if not Path(dir).is_dir():
         try:
-            os.mkdir(dir, 0o755)
+            Path(dir).mkdir(mode=0o755)
         except OSError:
             raise ConnectionError(f"Unable to create directory: {dir}")
     elif not os.access(dir, os.W_OK):
@@ -515,12 +516,12 @@ def _get_master_uri(props=None):
         return None
 
     # directory exists, touch the file and set permissions
-    filename = os.path.join(dir, "workflow.db")
+    filename = str(Path(dir) / "workflow.db")
     if not os.access(filename, os.F_OK):
         try:
             # touch the file
-            open(filename, "w").close()
-            os.chmod(filename, 0o600)
+            Path(filename).open("w").close()
+            Path(filename).chmod(0o600)
         except Exception as e:
             log.warning(f"unable to initialize MASTER db {filename}.")
             log.exception(e)
@@ -559,16 +560,17 @@ def _get_workflow_uri(props=None, submit_dir=None, top_dir=None):
         raise ConnectionError("DAG file name cannot be found in the braindump.txt.")
 
     # Create the sqlite db url
-    dag_file_name = os.path.basename(dag_file_name)
-    output_db_file = os.path.join(
-        top_level_wf_params["submit_dir"],
-        dag_file_name[: dag_file_name.find(".dag")] + ".stampede.db",
+    dag_file_name = Path(dag_file_name).name
+    output_db_file = str(
+        Path(top_level_wf_params["submit_dir"])
+        / (dag_file_name[: dag_file_name.find(".dag")] + ".stampede.db")
     )
 
     # if path does not exist, fallback on the submit_dir if provided
-    if not os.path.exists(output_db_file) and submit_dir:
-        output_db_file = os.path.join(
-            submit_dir, dag_file_name[: dag_file_name.find(".dag")] + ".stampede.db"
+    if not Path(output_db_file).exists() and submit_dir:
+        output_db_file = str(
+            Path(submit_dir)
+            / (dag_file_name[: dag_file_name.find(".dag")] + ".stampede.db")
         )
 
     return "sqlite:///" + output_db_file
@@ -600,12 +602,12 @@ def _check_db_permissions(dburi, db_type, mask=None):
         path = urlparse(dburi).path[1:]
         if db_type:
             if db_type == DBType.MASTER or db_type == DBType.WORKFLOW:
-                os.chmod(path, 0o744)
-        elif path == os.path.expanduser("~") + "/.pegasus/workflow.db":
-            os.chmod(path, 0o744)
+                Path(path).chmod(0o744)
+        elif path == str(Path("~").expanduser() / ".pegasus" / "workflow.db"):
+            Path(path).chmod(0o744)
 
         if mask:
-            os.chmod(path, mask)
+            Path(path).chmod(mask)
 
 
 def _parse_props(dburi, props, db_type=None, connect_args=None):
@@ -696,8 +698,8 @@ def _parse_top_level_wf_params(submit_dir, top_dir):
         return top_level_wf_params
 
     while True:
-        dir = os.path.abspath(os.path.join(os.path.abspath(dir), ".."))
-        if dir == os.path.realpath("/.."):
+        dir = Path(str(Path(Path(dir).resolve()) / "..")).resolve()
+        if dir == str(Path("/..").resolve()):
             top_level_wf_params = None
             break
 
@@ -722,9 +724,9 @@ def _backup_db(dburi):
     mask = None
     if urlparse(dburi).scheme == "sqlite":
         db_path = urlparse(dburi).path[1:]
-        if os.path.isfile(db_path):
+        if Path(db_path).is_file():
             log.info(f"Rotating sqlite db file {db_path}")
-            mask = os.stat(db_path)[ST_MODE]
+            mask = Path(db_path).stat()[ST_MODE]
             rotated_backup_file = utils.rotate_log_file(db_path)
             log.info(f"Rotated sqlite db file to {rotated_backup_file}")
 
@@ -764,5 +766,5 @@ def _truncate_previous_backup_file(backup_file, prefix):
 def _db_is_file(dburi):
     if urlparse(dburi).scheme == "sqlite":
         db_path = urlparse(dburi).path[1:]
-        return os.path.isfile(db_path)
+        return Path(db_path).is_file()
     return True

--- a/packages/pegasus-python/src/Pegasus/db/ensembles.py
+++ b/packages/pegasus-python/src/Pegasus/db/ensembles.py
@@ -1,8 +1,8 @@
 import json
-import os
 import re
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
 
 from flask import url_for
 from sqlalchemy import delete, func, select, sql, update
@@ -111,7 +111,7 @@ class Ensemble(EnsembleBase):
     def get_localdir(self):
         u = user.get_user_by_username(self.username)
         edir = u.get_ensembles_dir()
-        return os.path.join(edir, self.name)
+        return str(Path(edir) / self.name)
 
     def get_object(self):
         return {
@@ -196,7 +196,7 @@ class EnsembleWorkflow(EnsembleBase):
         edir = self.ensemble.get_localdir()
         wf = self.name
         filename = f"{wf}.{suffix}"
-        return os.path.join(edir, filename)
+        return str(Path(edir) / filename)
 
     def get_basedir(self):
         return self.basedir
@@ -396,8 +396,8 @@ class Ensembles:
         if cleanup is not None:
             f.write(f"--cleanup {cleanup} \\\n")
 
-        f.write(f"--dir {os.path.join(basedir, 'submit')} \\\n")
-        f.write(f"--dax {os.path.join(bundledir, dax)} \\\n")
+        f.write(f"--dir {str(Path(basedir) / 'submit')} \\\n")
+        f.write(f"--dax {str(Path(bundledir) / dax)} \\\n")
         f.write(f"--input-dir {bundledir} \n")
 
         f.write("exit $?")

--- a/packages/pegasus-python/src/Pegasus/exitcode.py
+++ b/packages/pegasus-python/src/Pegasus/exitcode.py
@@ -10,11 +10,11 @@ scans for user-supplied success/failure messages, and optionally generates a
 import atexit
 import datetime
 import json
-import os
 import re
 import sys
 import uuid
 from optparse import OptionParser
+from pathlib import Path
 
 SUBMIT_FILE_UPDATE_ENABLED = True
 try:
@@ -84,7 +84,7 @@ def rotate_file(outfile, errfile):
     retry = None
     for i in range(0, 1000):
         candidate = f"{outfile}.{i:03d}"
-        if not os.path.isfile(candidate):
+        if not Path(candidate).is_file():
             retry = i
             break
 
@@ -97,13 +97,13 @@ def rotate_file(outfile, errfile):
 
     # rename .out to .out.000
     newout = f"{basename}.out.{retry:03d}"
-    os.rename(outfile, newout)
+    Path(outfile).rename(newout)
 
     # rename .err to .err.000 if it exists
     newerr = None
-    if os.path.isfile(errfile):
+    if Path(errfile).is_file():
         newerr = f"{basename}.err.{retry:03d}"
-        os.rename(errfile, newerr)
+        Path(errfile).rename(newerr)
 
     return newout, newerr
 
@@ -119,10 +119,10 @@ def readfile(filename):
     :rtype: str
     """
     # If the file does not exits, return empty string
-    if filename is None or not os.path.isfile(filename):
+    if filename is None or not Path(filename).is_file():
         return ""
 
-    f = open(filename)
+    f = Path(filename).open()
     try:
         return f.read()
     finally:
@@ -357,7 +357,7 @@ def append_to_wf_metadata_log(files_metadata, logfile):
     :return:
     """
     # writing to log file (concurrency safe)
-    with open(logfile, "a", encoding="utf8") as outfile:
+    with Path(logfile).open("a", encoding="utf8") as outfile:
         for file_metadata in files_metadata:
             res = file_metadata.convert_to_rce()
             outfile.write(res + "\n")
@@ -402,7 +402,7 @@ def exitcode(
     :type generate_meta: bool
     :raises JobFailed: If the job is determined to have failed.
     """
-    if not os.path.isfile(outfile):
+    if not Path(outfile).is_file():
         raise JobFailed(f"{outfile} does not exist")
 
     errfile = get_errfile(outfile)
@@ -458,8 +458,8 @@ def exitcode(
     if generate_meta:
         files_metadata = parse_metadata_from_kickstart(outfile)
         # always generate a meta file even if it is a zero byte file
-        directory = os.path.dirname(meta_file)
-        basename = os.path.basename(meta_file)
+        directory = Path(meta_file).parent
+        basename = Path(meta_file).name
         Metadata.write_to_jsonfile(
             files_metadata, directory, basename, prefix="pegasus-exitcode"
         )
@@ -499,12 +499,12 @@ def parse_metadata_from_kickstart(outfile):
 def update_job_submit_file(outfile, retry):
     # figure out the job submit file from the .out file
     jobname, sub_file = get_sub_file(outfile)
-    if not os.path.exists(sub_file):
+    if not Path(sub_file).exists():
         raise JobFailed(f"Could not find job submit file {sub_file}")
 
     j = Job(
         name=jobname,
-        job_submit_dir=os.path.dirname(sub_file),
+        job_submit_dir=Path(sub_file).parent,
         wf_uuid=None,
         job_submit_seq=None,
     )
@@ -674,11 +674,11 @@ def _get_job_runtime(error_file):
     :return: the duration logged if a PegasusLite job, else None
     """
     runtime = None
-    if not os.path.isfile(error_file):
+    if not Path(error_file).is_file():
         return runtime
 
     # Read the file first
-    f = open(error_file)
+    f = Path(error_file).open()
     txt = f.read()
     f.close()
 
@@ -717,13 +717,13 @@ def _write_logs(log_filename):
         std_out.close()
         std_err.close()
 
-        with open(std_out.name) as sout:
+        with Path(std_out.name).open() as sout:
             log["std_out"] = sout.read()
-        with open(std_err.name) as serr:
+        with Path(std_err.name).open() as serr:
             log["std_err"] = serr.read()
 
         # writing to log file (concurrency safe)
-        with open(log_filename, "a", encoding="utf8") as outfile:
+        with Path(log_filename).open("a", encoding="utf8") as outfile:
             res = json.dumps(log, ensure_ascii=False)
             outfile.write(res + "\n")
 
@@ -843,8 +843,8 @@ def main(args):
     if options.log_filename:
         # temporary log files
         tmp_log_name = "_exit-code-" + str(uuid.uuid4())
-        tmp_log_files.append(open(tmp_log_name + ".out", "w"))
-        tmp_log_files.append(open(tmp_log_name + ".err", "w"))
+        tmp_log_files.append(Path(tmp_log_name + ".out").open("w"))
+        tmp_log_files.append(Path(tmp_log_name + ".err").open("w"))
 
     try:
         log["name"] = outfile
@@ -894,4 +894,4 @@ def remove_temporary_files():
     """
     # cleaning temporary files
     for tmp_file in tmp_log_files:
-        os.remove(tmp_file.name)
+        Path(tmp_file.name).unlink()

--- a/packages/pegasus-python/src/Pegasus/init.py
+++ b/packages/pegasus-python/src/Pegasus/init.py
@@ -6,6 +6,7 @@ import tempfile
 import time
 import urllib.request
 import zipfile
+from pathlib import Path
 
 import click
 
@@ -19,27 +20,25 @@ update_config_timeout = 24 * 60 * 60
 PEGASUS_HOME = os.getenv("PEGASUS_HOME")
 
 #### Default data path ####
-pegasushub_data_path = os.path.expanduser("~/.pegasus/pegasushub")
+pegasushub_data_path = Path("~/.pegasus/pegasushub").expanduser()
 
 #### Pegasus major_minor_version ####
 pegasus_major_minor_version = (
-    subprocess.check_output(
-        [os.path.join(PEGASUS_HOME, "bin", "pegasus-version"), "-m"]
-    )
+    subprocess.check_output([str(Path(PEGASUS_HOME) / "bin" / "pegasus-version"), "-m"])
     .strip()
     .decode("utf-8")
 )
 
 #### Url to Sites.py on pegasushub and Sites.py location ####
 pegasushub_site_catalogs_url = f"https://raw.githubusercontent.com/pegasushub/pegasus-site-catalogs/{pegasus_major_minor_version}/Sites.py"
-wf_sites = os.path.join(pegasushub_data_path, f"{pegasus_major_minor_version}/Sites.py")
+wf_sites = str(Path(pegasushub_data_path) / f"{pegasus_major_minor_version}/Sites.py")
 
 
 def update_site_catalogs(wf_sites):
-    if not os.path.isfile(wf_sites):
-        os.makedirs(wf_sites[: wf_sites.rfind("/")], exist_ok=True)
+    if not Path(wf_sites).is_file():
+        Path(wf_sites[: wf_sites.rfind("/")]).mkdir(exist_ok=True, parents=True)
         urllib.request.urlretrieve(pegasushub_site_catalogs_url, wf_sites)
-    elif int(os.path.getmtime(wf_sites)) < time.time() - update_config_timeout:
+    elif int(Path(wf_sites).stat().st_mtime) < time.time() - update_config_timeout:
         urllib.request.urlretrieve(pegasushub_site_catalogs_url, wf_sites)
 
 
@@ -48,16 +47,17 @@ pegasushub_workflows_url = "https://raw.githubusercontent.com/pegasushub/pegasus
 
 
 def update_workflow_list(wf_gallery):
-    if not os.path.isfile(wf_gallery):
-        os.makedirs(wf_gallery[: wf_gallery.rfind("/")], exist_ok=True)
+    if not Path(wf_gallery).is_file():
+        Path(wf_gallery[: wf_gallery.rfind("/")]).mkdir(exist_ok=True, parents=True)
         urllib.request.urlretrieve(pegasushub_workflows_url, wf_gallery)
-    elif int(os.path.getmtime(wf_gallery)) < time.time() - update_config_timeout:
+    elif int(Path(wf_gallery).stat().st_mtime) < time.time() - update_config_timeout:
         urllib.request.urlretrieve(pegasushub_workflows_url, wf_gallery)
 
 
 #### Update Site Catalogs and load Sites ####
 update_site_catalogs(wf_sites)
-sys.path.insert(0, os.path.join(pegasushub_data_path, pegasus_major_minor_version))
+sys.path.insert(0, str(Path(pegasushub_data_path) / pegasus_major_minor_version))
+
 import Sites  # noqa: E402
 
 
@@ -87,7 +87,7 @@ def console_select_site(wf_dir):
 
     # default base directories for scratch and storage space
     # rooted in the wf dir where the example is created
-    default_shared_scratch = os.path.join(os.getcwd(), wf_dir)
+    default_shared_scratch = str(Path(Path.cwd()) / wf_dir)
     default_shared_storage = default_shared_scratch
 
     #### Select Site ####
@@ -206,7 +206,7 @@ def print_workflows(workflows_available):
 
 def clone_workflow(wf_dir, workflow):
     zip_url = f"https://github.com/{workflow['organization']}/{workflow['repo_name']}/archive/HEAD.zip"
-    dest = os.path.join(os.getcwd(), wf_dir, workflow["repo_name"])
+    dest = str(Path(Path.cwd()) / wf_dir / workflow["repo_name"])
 
     click.echo(
         f"Fetching workflow from https://github.com/{workflow['organization']}/{workflow['repo_name']}.git"
@@ -214,7 +214,7 @@ def clone_workflow(wf_dir, workflow):
 
     try:
         with tempfile.TemporaryDirectory() as tmp:
-            zip_path = os.path.join(tmp, "repo.zip")
+            zip_path = str(Path(tmp) / "repo.zip")
             urllib.request.urlretrieve(zip_url, zip_path)
             with zipfile.ZipFile(zip_path) as zf:
                 for info in zf.infolist():
@@ -222,12 +222,8 @@ def clone_workflow(wf_dir, workflow):
                     # store st_mode (0 if not from Unix)
                     mode = info.external_attr >> 16
                     if mode:
-                        os.chmod(path, mode & 0o777)
-            extracted = next(
-                os.path.join(tmp, d)
-                for d in os.listdir(tmp)
-                if os.path.isdir(os.path.join(tmp, d))
-            )
+                        Path(path).chmod(mode & 0o777)
+            extracted = next(str(path) for path in Path(tmp).iterdir() if path.is_dir())
             shutil.move(extracted, dest)
     except Exception:
         click.echo("This repository doesn't exist in this location or it's private.")
@@ -239,9 +235,9 @@ def read_pegasushub_config(wf_dir, workflow):
     config = None
 
     config = yaml.load(
-        open(
-            os.path.join(os.getcwd(), wf_dir, workflow["repo_name"], ".pegasushub.yml")
-        )
+        Path(
+            str(Path(Path.cwd()) / wf_dir / workflow["repo_name"] / ".pegasushub.yml")
+        ).open()
     )
 
     if config:
@@ -281,11 +277,11 @@ pegasus-plan --conf pegasus.properties \\
     --force \\
     {workflow_file}"""
 
-    with open("plan.sh", "w+") as g:
+    with Path("plan.sh").open("w+") as g:
         g.write(plan_script)
         g.write("\n")
 
-    os.chmod("plan.sh", 0o775)
+    Path("plan.sh").chmod(0o775)
 
     return
 
@@ -295,11 +291,11 @@ def create_generate_script(commands):
         os.getenv("PYTHONPATH"), "\n".join(commands)
     )
 
-    with open("generate.sh", "w+") as g:
+    with Path("generate.sh").open("w+") as g:
         g.write(generate_script)
         g.write("\n")
 
-    os.chmod("generate.sh", 0o775)
+    Path("generate.sh").chmod(0o775)
 
     return
 
@@ -342,7 +338,7 @@ def create_workflow(
 Please refer to Pegasus Documentation https://pegasus.isi.edu/documentation/reference-guide/data-management.html#credentials-management"""
             )
 
-    old_dir = os.getcwd()
+    old_dir = Path.cwd()
     os.chdir(wf_dir)
 
     exec_site = Sites.MySite(
@@ -373,7 +369,7 @@ Please refer to Pegasus Documentation https://pegasus.isi.edu/documentation/refe
     for pre_script in pre_scripts:
         exec_script = pegasushub_config["scripts"][pre_script]
         if not exec_script.startswith("/"):
-            exec_script = os.path.join("./", workflow["repo_name"], exec_script)
+            exec_script = str(Path("./") / workflow["repo_name"] / exec_script)
         subprocess.run(exec_script, shell=True)
         commands.append(exec_script)
 
@@ -382,14 +378,14 @@ Please refer to Pegasus Documentation https://pegasus.isi.edu/documentation/refe
     for script in scripts:
         exec_script = pegasushub_config["scripts"][script]
         if not exec_script.startswith("/"):
-            exec_script = os.path.join("./", workflow["repo_name"], exec_script)
+            exec_script = str(Path("./") / workflow["repo_name"] / exec_script)
         subprocess.run(exec_script, shell=True)
         commands.append(exec_script)
 
     commands.append("#### Executing Workflow Generator ####")
     exec_script = pegasushub_config["scripts"]["generator"]
     if not exec_script.startswith("/"):
-        exec_script = os.path.join("./", workflow["repo_name"], exec_script)
+        exec_script = str(Path("./") / workflow["repo_name"] / exec_script)
     generate_workflow_cmd = " ".join(
         [exec_script, "-s", "-e", exec_site.exec_site_name, "-o", "workflow.yml"]
     )
@@ -401,7 +397,7 @@ Please refer to Pegasus Documentation https://pegasus.isi.edu/documentation/refe
     for post_script in post_scripts:
         exec_script = pegasushub_config["scripts"][post_script]
         if not exec_script.startswith("/"):
-            exec_script = os.path.join("./", workflow["repo_name"], exec_script)
+            exec_script = str(Path("./") / workflow["repo_name"] / exec_script)
         subprocess.run(exec_script, shell=True)
         commands.append(exec_script)
 
@@ -435,7 +431,7 @@ Please refer to Pegasus Documentation https://pegasus.isi.edu/documentation/refe
 
 
 def read_workflows(wf_gallery, site):
-    data = yaml.load(open(wf_gallery))
+    data = yaml.load(Path(wf_gallery).open())
     workflows_available = [
         x
         for x in data
@@ -461,7 +457,7 @@ CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 @click.option(
     "-w",
     "--workflow-gallery",
-    default=os.path.expanduser("~/.pegasus/pegasushub/workflows.yml"),
+    default=Path("~/.pegasus/pegasushub/workflows.yml").expanduser(),
     type=click.Path(),
     show_default=True,
     help="Workflow Gallery File.",
@@ -480,12 +476,12 @@ def main(directory, workflow_gallery):
     may alter the workflow and catalogs generated by Pegasus Init.
     """
 
-    if os.path.isfile(directory) or os.path.isdir(directory):
+    if Path(directory).is_file() or Path(directory).is_dir():
         click.echo("The given directory name already exists")
         click.echo("Exiting...")
         exit()
 
-    if workflow_gallery == os.path.expanduser("~/.pegasus/pegasushub/workflows.yml"):
+    if workflow_gallery == Path("~/.pegasus/pegasushub/workflows.yml").expanduser():
         update_workflow_list(workflow_gallery)
 
     (

--- a/packages/pegasus-python/src/Pegasus/monitoring/event_output.py
+++ b/packages/pegasus-python/src/Pegasus/monitoring/event_output.py
@@ -26,6 +26,7 @@ import ssl
 import time
 import traceback
 import urllib.parse
+from pathlib import Path
 from threading import Thread
 
 from Pegasus import json
@@ -261,9 +262,9 @@ class FileEventSink(EventSink):
     def __init__(self, path, restart=False, encoder=None, **kw):
         super().__init__()
         if restart:
-            self._output = open(path, "w", 1)
+            self._output = Path(path).open("w", 1)
         else:
-            self._output = open(path, "a", 1)
+            self._output = Path(path).open("a", 1)
         self._encoder = encoder
 
     def send(self, event, kw):

--- a/packages/pegasus-python/src/Pegasus/monitoring/job.py
+++ b/packages/pegasus-python/src/Pegasus/monitoring/job.py
@@ -21,9 +21,9 @@ This file implements the Job class for pegasus-monitord.
 import collections
 import json
 import logging
-import os
 import re
 from io import StringIO
+from pathlib import Path
 
 from Pegasus.tools import utils
 
@@ -303,7 +303,7 @@ class Job:
                 self._main_job_multiplier_factor = int(my_multiplier_factor)
             except ValueError:
                 logger.warning(
-                    f"{os.path.basename(submit_file)}: cannot convert multiplier factor: {my_multiplier_factor}"
+                    f"{Path(submit_file).name}: cannot convert multiplier factor: {my_multiplier_factor}"
                 )
                 self._main_job_multiplier_factor = None
 
@@ -394,7 +394,7 @@ class Job:
 
         # Update stat record for submit file
         try:
-            my_stats = os.stat(submit_file)
+            my_stats = Path(submit_file).stat()
         except OSError:
             # Could not stat file
             logger.error(f"stat {submit_file}")
@@ -413,7 +413,7 @@ class Job:
             parse_environment = True
 
         try:
-            SUB = open(submit_file)
+            SUB = Path(submit_file).open()
         except OSError:
             logger.error(f"unable to parse {submit_file}")
             return my_result, my_site
@@ -457,19 +457,19 @@ class Job:
                 my_input = re_parse_input.search(my_line).group(1)
                 # Remove quotes, if any
                 my_input = my_input.strip('"')
-                self._input_file = os.path.normpath(my_input)
+                self._input_file = str(Path(my_input))
             elif re_parse_output.search(my_line):
                 # Found line with output file
                 my_output = re_parse_output.search(my_line).group(1)
                 # Remove quotes, if any
                 my_output = my_output.strip('"')
-                self._output_file = os.path.normpath(my_output)
+                self._output_file = str(Path(my_output))
             elif re_parse_error.search(my_line):
                 # Found line with error file
                 my_error = re_parse_error.search(my_line).group(1)
                 # Remove quotes, if any
                 my_error = my_error.strip('"')
-                self._error_file = os.path.normpath(my_error)
+                self._error_file = str(Path(my_error))
             elif parse_environment and re_parse_environment.search(my_line):
                 self._job_dagman_out = self.extract_dagman_out_from_condor_env(my_line)
                 if self._job_dagman_out is None:
@@ -746,10 +746,10 @@ class Job:
         # Finally, read error file only
         run_dir = self._job_submit_dir
         basename = self.get_rotated_err_filename()
-        my_err_file = os.path.join(run_dir, basename)
+        my_err_file = str(Path(run_dir) / basename)
 
         try:
-            ERR = open(my_err_file)
+            ERR = Path(my_err_file).open()
             # PM-1274 parse any monitoring events such as integrity related
             # from PegasusLite .err file
             job_stderr = self.split_task_output(ERR.read())
@@ -799,10 +799,10 @@ class Job:
             basename = self._exec_job_id + ".out"
             if self._has_rotated_stdout_err_files:
                 basename += f".{self._job_output_counter:03d}"
-            out_file = os.path.join(run_dir, basename)
+            out_file = str(Path(run_dir) / basename)
 
         try:
-            OUT = open(out_file)
+            OUT = Path(out_file).open()
             job_stdout = self.split_task_output(OUT.read())
             buf = job_stdout.user_data
             if len(buf) > my_max_encoded_length:

--- a/packages/pegasus-python/src/Pegasus/monitoring/job.py
+++ b/packages/pegasus-python/src/Pegasus/monitoring/job.py
@@ -21,6 +21,7 @@ This file implements the Job class for pegasus-monitord.
 import collections
 import json
 import logging
+import os
 import re
 from io import StringIO
 from pathlib import Path
@@ -457,19 +458,19 @@ class Job:
                 my_input = re_parse_input.search(my_line).group(1)
                 # Remove quotes, if any
                 my_input = my_input.strip('"')
-                self._input_file = str(Path(my_input))
+                self._input_file = os.path.normpath(my_input)
             elif re_parse_output.search(my_line):
                 # Found line with output file
                 my_output = re_parse_output.search(my_line).group(1)
                 # Remove quotes, if any
                 my_output = my_output.strip('"')
-                self._output_file = str(Path(my_output))
+                self._output_file = os.path.normpath(my_output)
             elif re_parse_error.search(my_line):
                 # Found line with error file
                 my_error = re_parse_error.search(my_line).group(1)
                 # Remove quotes, if any
                 my_error = my_error.strip('"')
-                self._error_file = str(Path(my_error))
+                self._error_file = os.path.normpath(my_error)
             elif parse_environment and re_parse_environment.search(my_line):
                 self._job_dagman_out = self.extract_dagman_out_from_condor_env(my_line)
                 if self._job_dagman_out is None:

--- a/packages/pegasus-python/src/Pegasus/monitoring/metadata.py
+++ b/packages/pegasus-python/src/Pegasus/monitoring/metadata.py
@@ -20,9 +20,9 @@ This file implements the metadata related classes for pegasus-monitord.
 # Import Python modules
 import json
 import logging
-import os
 import tempfile
 from io import StringIO
+from pathlib import Path
 
 __author__ = "Karan Vahi <vahi@isi.edu>"
 
@@ -65,9 +65,9 @@ class Metadata:
             )
             jsonify(metadata_list, temp_file)
             logger.debug("Written out metadata to %s", temp_file.name)
-            os.chmod(temp_file.name, 0o644)
+            Path(temp_file.name).chmod(0o644)
             # rename the file to the name to assure atomicity
-            os.rename(temp_file.name, os.path.join(directory, name))
+            Path(temp_file.name).rename(str(Path(directory) / name))
 
         except Exception as e:
             # Error sending this event... disable the sink from now on...

--- a/packages/pegasus-python/src/Pegasus/monitoring/notifications.py
+++ b/packages/pegasus-python/src/Pegasus/monitoring/notifications.py
@@ -27,6 +27,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from pathlib import Path
 
 from Pegasus.tools import utils
 
@@ -55,15 +56,13 @@ class Notifications:
         self._pending_notifications = []
         self._max_parallel_notifications = max_parallel_notifications
         self._notifications_timeout = notifications_timeout
-        self._notifications_fn = os.path.join(
-            notification_file_prefix, NOTIFICATION_FILE
-        )
+        self._notifications_fn = str(Path(notification_file_prefix) / NOTIFICATION_FILE)
         self._notifications_log = None
         self._notifications = {}
 
         # Open notifications' log file
         try:
-            self._notifications_log = open(self._notifications_fn, "a")
+            self._notifications_log = Path(self._notifications_fn).open("a")
         except OSError:
             logger.critical("cannot create notifications' log file... exiting...")
             sys.exit(1)
@@ -119,8 +118,8 @@ class Notifications:
 
         # Finally, clean up files...
         try:
-            os.unlink(my_out_fn)
-            os.unlink(my_err_fn)
+            Path(my_out_fn).unlink()
+            Path(my_err_fn).unlink()
         except OSError:
             # No error here...
             pass
@@ -194,7 +193,7 @@ class Notifications:
                             self._notifications_log.write("\n")
                             self._notifications_log.write("stdout:\n")
                             try:
-                                my_f = open(my_finished_out_fn)
+                                my_f = Path(my_finished_out_fn).open()
                                 for line in my_f:
                                     self._notifications_log.write(line)
                             except OSError:
@@ -206,7 +205,7 @@ class Notifications:
                             self._notifications_log.write("\n")
                             self._notifications_log.write("stderr:\n")
                             try:
-                                my_f = open(my_finished_err_fn)
+                                my_f = Path(my_finished_err_fn).open()
                                 for line in my_f:
                                     self._notifications_log.write(line)
                             except OSError:
@@ -230,13 +229,13 @@ class Notifications:
 
                     # Now, delete output and error files
                     try:
-                        os.unlink(my_finished_out_fn)
+                        Path(my_finished_out_fn).unlink()
                     except OSError:
                         logger.warning(
                             f"error deleting notification stdout file: {my_finished_out_fn}. continuing..."
                         )
                     try:
-                        os.unlink(my_finished_err_fn)
+                        Path(my_finished_err_fn).unlink()
                     except OSError:
                         logger.warning(
                             f"error deleting notification stderr file: {my_finished_err_fn}. continuing..."
@@ -305,15 +304,15 @@ class Notifications:
 
             # Open output and error files for the notification script
             try:
-                my_f_out = open(my_out_fn, "w")
-                my_f_err = open(my_err_fn, "w")
+                my_f_out = Path(my_out_fn).open("w")
+                my_f_err = Path(my_err_fn).open("w")
             except OSError:
                 logger.warning(
                     f"cannot open temp files for notification: {my_notification}... skipping..."
                 )
                 try:
-                    os.unlink(my_out_fn)
-                    os.unlink(my_err_fn)
+                    Path(my_out_fn).unlink()
+                    Path(my_err_fn).unlink()
                 except OSError:
                     # No error here...
                     pass
@@ -331,8 +330,8 @@ class Notifications:
                 try:
                     my_f_out.close()
                     my_f_err.close()
-                    os.unlink(my_out_fn)
-                    os.unlink(my_err_fn)
+                    Path(my_out_fn).unlink()
+                    Path(my_err_fn).unlink()
                 except OSError:
                     logger.warning(
                         f"found problem cleaning up notification: {my_notification}... skipping..."
@@ -347,8 +346,8 @@ class Notifications:
                 try:
                     my_f_out.close()
                     my_f_err.close()
-                    os.unlink(my_out_fn)
-                    os.unlink(my_err_fn)
+                    Path(my_out_fn).unlink()
+                    Path(my_err_fn).unlink()
                 except OSError:
                     logger.warning(
                         f"found problem cleaning up notification: {my_notification}... skipping..."
@@ -449,7 +448,7 @@ class Notifications:
 
         # Open file
         try:
-            NOTIFY = open(notify_file)
+            NOTIFY = Path(notify_file).open()
         except OSError:
             logger.warning(
                 f"cannot load notification file {notify_file}, continuing without notifications"
@@ -714,8 +713,8 @@ class Notifications:
                 # We are in some other state...
                 continue
 
-            my_output = os.path.join(wf._original_submit_dir, job._output_file)
-            my_error = os.path.join(wf._original_submit_dir, job._error_file)
+            my_output = str(Path(wf._original_submit_dir) / job._output_file)
+            my_error = str(Path(wf._original_submit_dir) / job._error_file)
             # Use the rotated file names if at the end of the job
             if k != "start":
                 my_output = my_output + f".{job._job_output_counter:03d}"
@@ -802,11 +801,11 @@ class Notifications:
 
             # Here, we always use the rotated file names as the invocation has already finished...
             my_output = (
-                os.path.join(wf._original_submit_dir, job._output_file)
+                str(Path(wf._original_submit_dir) / job._output_file)
                 + f".{job._job_output_counter:03d}"
             )
             my_error = (
-                os.path.join(wf._original_submit_dir, job._error_file)
+                str(Path(wf._original_submit_dir) / job._error_file)
                 + f".{job._job_output_counter:03d}"
             )
 

--- a/packages/pegasus-python/src/Pegasus/monitoring/workflow.py
+++ b/packages/pegasus-python/src/Pegasus/monitoring/workflow.py
@@ -25,6 +25,7 @@ import socket
 import sys
 import time
 import traceback
+from pathlib import Path
 
 from Pegasus.monitoring.job import IntegrityMetric, Job
 from Pegasus.tools import kickstart_parser, utils
@@ -192,10 +193,10 @@ class Workflow:
             )
             return
 
-        dag_file = os.path.join(self._run_dir, dag_file)
+        dag_file = str(Path(self._run_dir) / dag_file)
 
         try:
-            DAG = open(dag_file)
+            DAG = Path(dag_file).open()
         except Exception:
             logger.warning(f"unable to read {dag_file}!")
         else:
@@ -208,7 +209,7 @@ class Workflow:
                     if my_match:
                         if not my_match.group(3):
                             my_jobid = my_match.group(1)
-                            my_sub = os.path.join(self._run_dir, my_match.group(2))
+                            my_sub = str(Path(self._run_dir) / my_match.group(2))
                             # Found submit file for not-DONE job
                             if my_jobid in self._job_info:
                                 # Entry already exists for this job, just collect submit file info
@@ -315,7 +316,7 @@ class Workflow:
                         if my_dir is None:
                             # SUBDAG EXTERNAL line without DIR, let's get it from the DAG path
                             if my_dag is not None:
-                                my_dir = os.path.dirname(my_dag)
+                                my_dir = Path(my_dag).parent
                         if my_jobid in self._job_info:
                             # Entry already exists for this job, just set subdag flag, and dag/dir info
                             self._job_info[my_jobid][5] = True
@@ -360,10 +361,10 @@ class Workflow:
         was found.
         """
         jobname = job._exec_job_id
-        in_file = os.path.join(job._job_submit_dir, jobname) + ".in"
+        in_file = str(Path(job._job_submit_dir) / jobname) + ".in"
 
         try:
-            IN = open(in_file)
+            IN = Path(in_file).open()
         except Exception:
             logger.warning(f"unable to read {in_file}!")
             return None
@@ -387,7 +388,7 @@ class Workflow:
                     my_task_info = tasks[my_task_id]
                 except Exception:
                     logger.warning(
-                        f"cannot locate task {my_task_id:d} in dictionary... skipping this task for job: {jobname}, dag file: {os.path.join(self._run_dir, self._dag_file_name)}"
+                        f"cannot locate task {my_task_id:d} in dictionary... skipping this task for job: {jobname}, dag file: {str(Path(self._run_dir) / self._dag_file_name)}"
                     )
                     continue
                 my_task_info["transformation"] = my_transformation
@@ -413,7 +414,7 @@ class Workflow:
                     my_task_info = tasks[tasks_found]
                 except Exception:
                     logger.warning(
-                        f"cannot locate task {my_task_id:d} in dictionary... skipping this task for job: {jobname}, dag file: {os.path.join(self._run_dir, self._dag_file_name)}"
+                        f"cannot locate task {my_task_id:d} in dictionary... skipping this task for job: {jobname}, dag file: {str(Path(self._run_dir) / self._dag_file_name)}"
                     )
                     continue
                 my_task_info["argument-vector"] = my_argv
@@ -435,14 +436,14 @@ class Workflow:
         """
 
         if self._output_dir is None:
-            my_fn = os.path.join(self._run_dir, MONITORD_STATE_FILE)
+            my_fn = str(Path(self._run_dir) / MONITORD_STATE_FILE)
         else:
-            my_fn = os.path.join(
-                self._output_dir, f"{self._wf_uuid}-{MONITORD_STATE_FILE}"
+            my_fn = str(
+                Path(self._output_dir) / f"{self._wf_uuid}-{MONITORD_STATE_FILE}"
             )
 
         try:
-            INPUT = open(my_fn)
+            INPUT = Path(my_fn).open()
         except Exception:
             logger.info(f"cannot open state file {my_fn}, continuing without state...")
             return
@@ -487,14 +488,14 @@ class Workflow:
         """
 
         if self._output_dir is None:
-            my_fn = os.path.join(self._run_dir, MONITORD_STATE_FILE)
+            my_fn = str(Path(self._run_dir) / MONITORD_STATE_FILE)
         else:
-            my_fn = os.path.join(
-                self._output_dir, f"{self._wf_uuid}-{MONITORD_STATE_FILE}"
+            my_fn = str(
+                Path(self._output_dir) / f"{self._wf_uuid}-{MONITORD_STATE_FILE}"
             )
 
         try:
-            OUT = open(my_fn, "w")
+            OUT = Path(my_fn).open("w")
         except Exception:
             logger.error(f"cannot open state file {my_fn}")
             return
@@ -531,15 +532,15 @@ class Workflow:
         time that was processed by pegasus-monitord.
         """
         if self._output_dir is None:
-            my_recover_file = os.path.join(self._run_dir, MONITORD_RECOVER_FILE)
+            my_recover_file = str(Path(self._run_dir) / MONITORD_RECOVER_FILE)
         else:
-            my_recover_file = os.path.join(
-                self._output_dir, f"{self._wf_uuid}-{MONITORD_RECOVER_FILE}"
+            my_recover_file = str(
+                Path(self._output_dir) / f"{self._wf_uuid}-{MONITORD_RECOVER_FILE}"
             )
 
         if os.access(my_recover_file, os.F_OK):
             try:
-                RECOVER = open(my_recover_file)
+                RECOVER = Path(my_recover_file).open()
                 for line in RECOVER:
                     line = line.strip()
                     my_key, my_value = line.split(" ", 1)
@@ -566,13 +567,13 @@ class Workflow:
             return
 
         if self._output_dir is None:
-            my_recover_file = os.path.join(self._run_dir, MONITORD_RECOVER_FILE)
+            my_recover_file = str(Path(self._run_dir) / MONITORD_RECOVER_FILE)
         else:
-            my_recover_file = os.path.join(
-                self._output_dir, f"{self._wf_uuid}-{MONITORD_RECOVER_FILE}"
+            my_recover_file = str(
+                Path(self._output_dir) / f"{self._wf_uuid}-{MONITORD_RECOVER_FILE}"
             )
         try:
-            RECOVER = open(my_recover_file, "w")
+            RECOVER = Path(my_recover_file).open("w")
         except Exception:
             logger.error(f"cannot open recover file: {my_recover_file}")
             return
@@ -869,9 +870,9 @@ class Workflow:
         """
         Remove monitord.done file if it already exists.
         """
-        if os.path.isfile(os.path.join(self._run_dir, MONITORD_DONE_FILE)):
+        if Path(str(Path(self._run_dir) / MONITORD_DONE_FILE)).is_file():
             try:
-                os.remove(os.path.join(self._run_dir, MONITORD_DONE_FILE))
+                Path(str(Path(self._run_dir) / MONITORD_DONE_FILE)).unlink()
             except BaseException:
                 pass
 
@@ -1055,16 +1056,14 @@ class Workflow:
 
         if "submit_dir" in wfparams:
             self._submit_dir = wfparams["submit_dir"]
-            self._original_submit_dir = os.path.normpath(wfparams["submit_dir"])
+            self._original_submit_dir = str(Path(wfparams["submit_dir"]))
         else:
             # Use "run" if "submit_dir" not found
             if "run" in wfparams:
                 self._submit_dir = wfparams["run"]
             # Use "jsd" if "submit_dir" is not found
             if "jsd" in wfparams:
-                self._original_submit_dir = os.path.dirname(
-                    os.path.normpath(wfparams["jsd"])
-                )
+                self._original_submit_dir = Path(str(Path(wfparams["jsd"]))).parent
 
         self._fixed_addon_attrs["submit__dir"] = self._submit_dir
 
@@ -1109,13 +1108,13 @@ class Workflow:
 
         if self._output_dir is None:
             # Make sure we have an absolute path
-            self._jsd_file = os.path.join(rundir, my_jsd)
+            self._jsd_file = str(Path(rundir) / my_jsd)
         else:
-            self._jsd_file = os.path.join(
-                rundir, self._output_dir, f"{self._wf_uuid}-{my_jsd}"
+            self._jsd_file = str(
+                Path(rundir) / self._output_dir / f"{self._wf_uuid}-{my_jsd}"
             )
 
-        if not os.path.isfile(self._jsd_file):
+        if not Path(self._jsd_file).is_file():
             logger.info(f"creating new file {self._jsd_file}")
 
         try:
@@ -1127,7 +1126,7 @@ class Workflow:
                 logger.info(
                     f"Appending to existing jobstate.log replay_mode {self._replay_mode} previous_processed_line {self._previous_processed_line}"
                 )
-                self._JSDB = open(self._jsd_file, "ab", 0)
+                self._JSDB = Path(self._jsd_file).open("ab", 0)
             else:
                 # Rotate jobstate.log file, if any in case of replay
                 # mode of if we are starting from the beginning
@@ -1137,7 +1136,7 @@ class Workflow:
                 logger.info(
                     f" Rotating jobstate.log replay_mode {self._replay_mode} previous_processed_line {self._previous_processed_line}"
                 )
-                self._JSDB = open(self._jsd_file, "wb", 0)
+                self._JSDB = Path(self._jsd_file).open("wb", 0)
         except Exception:
             logger.critical(f"error creating/appending to {self._jsd_file}!")
             self._monitord_exit_code = 1
@@ -1150,7 +1149,7 @@ class Workflow:
                 self._notify_file = wfparams["notify"]
                 # Add rundir to notifications filename
                 if self._run_dir is not None:
-                    self._notify_file = os.path.join(self._run_dir, self._notify_file)
+                    self._notify_file = str(Path(self._run_dir) / self._notify_file)
                 # Read notification file
                 if (
                     self._notifications_manager.read_notification_file(
@@ -1168,10 +1167,10 @@ class Workflow:
 
         # Write monitord.started file
         if self._output_dir is None:
-            my_start_file = os.path.join(self._run_dir, MONITORD_START_FILE)
+            my_start_file = str(Path(self._run_dir) / MONITORD_START_FILE)
         else:
-            my_start_file = os.path.join(
-                self._output_dir, f"{self._wf_uuid}-{MONITORD_START_FILE}"
+            my_start_file = str(
+                Path(self._output_dir) / f"{self._wf_uuid}-{MONITORD_START_FILE}"
             )
 
         my_now = int(time.time())
@@ -1179,12 +1178,12 @@ class Workflow:
 
         # Remove monitord.done file, if it is there
         if self._output_dir is None:
-            os.path.join(self._run_dir, MONITORD_DONE_FILE)
+            str(Path(self._run_dir) / MONITORD_DONE_FILE)
         else:
-            os.path.join(self._output_dir, f"{self._wf_uuid}-{MONITORD_DONE_FILE}")
+            str(Path(self._output_dir) / f"{self._wf_uuid}-{MONITORD_DONE_FILE}")
 
         try:
-            os.unlink(my_touch_file)
+            Path(my_touch_file).unlink()
         except Exception:
             pass
 
@@ -1206,12 +1205,12 @@ class Workflow:
             # Create NetLogger parser
             my_bp_parser = NLSimpleParser(parse_date=False)
             # Figure out static data filename, and create full path name
-            my_bp_file = os.path.splitext(self._dag_file_name)[0] + ".static.bp"
-            self._static_bp_file = os.path.join(self._run_dir, my_bp_file)
+            my_bp_file = Path(self._dag_file_name).with_suffix(".static.bp").name
+            self._static_bp_file = str(Path(self._run_dir) / my_bp_file)
 
             # Open static bp file
             try:
-                my_static_file = open(self._static_bp_file)
+                my_static_file = Path(self._static_bp_file).open()
             except Exception:
                 logger.critical(
                     f"cannot find static bp file {self._static_bp_file}, exiting..."
@@ -1322,10 +1321,10 @@ class Workflow:
         my_workflow_end = int(time.time())
 
         if self._output_dir is None:
-            my_recover_file = os.path.join(self._run_dir, MONITORD_RECOVER_FILE)
+            my_recover_file = str(Path(self._run_dir) / MONITORD_RECOVER_FILE)
         else:
-            my_recover_file = os.path.join(
-                self._output_dir, f"{self._wf_uuid}-{MONITORD_RECOVER_FILE}"
+            my_recover_file = str(
+                Path(self._output_dir) / f"{self._wf_uuid}-{MONITORD_RECOVER_FILE}"
             )
 
         self.write_to_jobstate(
@@ -1338,20 +1337,20 @@ class Workflow:
 
         # Delete recovery file
         try:
-            os.unlink(my_recover_file)
+            Path(my_recover_file).unlink()
             logger.info(f"recovery file deleted: {my_recover_file}")
         except Exception:
             logger.warning(f"unable to remove recover file: {my_recover_file}")
 
         # Write monitord.done file
         if self._output_dir is None:
-            my_touch_name = os.path.join(self._run_dir, MONITORD_DONE_FILE)
+            my_touch_name = str(Path(self._run_dir) / MONITORD_DONE_FILE)
         else:
-            my_touch_name = os.path.join(
-                self._output_dir, f"{self._wf_uuid}-{MONITORD_DONE_FILE}"
+            my_touch_name = str(
+                Path(self._output_dir) / f"{self._wf_uuid}-{MONITORD_DONE_FILE}"
             )
         try:
-            TOUCH = open(my_touch_name, "w")
+            TOUCH = Path(my_touch_name).open("w")
             TOUCH.write(
                 f"{utils.isodate(my_workflow_end)} {my_workflow_end - self._workflow_start:.3f}\n"
             )
@@ -1367,7 +1366,7 @@ class Workflow:
             # Attempt to copy the condor common logfile to the current directory
             if self._condorlog is not None:
                 if (
-                    os.path.isfile(self._condorlog)
+                    Path(self._condorlog).is_file()
                     and os.access(self._condorlog, os.R_OK)
                     and self._condorlog.find("/") == 0
                 ):
@@ -1379,12 +1378,12 @@ class Workflow:
                     if my_status == 0:
                         # Copy successful
                         try:
-                            os.unlink(my_log)
+                            Path(my_log).unlink()
                         except Exception:
                             logger.error(f"removing {my_log}")
                         else:
                             try:
-                                os.rename(f"{my_log}.copy", my_log)
+                                Path(f"{my_log}.copy").rename(my_log)
                             except Exception:
                                 logger.error(f"renaming {my_log}.copy to {my_log}")
                             else:
@@ -2195,7 +2194,7 @@ class Workflow:
         if parse_kickstart:
             # Compose kickstart output file name (base is the filename before rotation)
             my_job_output_fn_base = (
-                os.path.join(my_job._job_submit_dir, my_job._exec_job_id) + ".out"
+                str(Path(my_job._job_submit_dir) / my_job._exec_job_id) + ".out"
             )
 
             # PM-793 if there is a postscript associated then a job has rotated stdout|stderr
@@ -2420,13 +2419,13 @@ class Workflow:
 
         basename = f"{job._exec_job_id}.in"
         # PM-833 the .in file should be picked up from job submit directory
-        input_file = os.path.join(job._job_submit_dir, basename)
+        input_file = str(Path(job._job_submit_dir) / basename)
         logger.info(
             f"Populating locations corresponding to succeeded registration job  {input_file} "
         )
 
         try:
-            SUB = open(input_file)
+            SUB = Path(input_file).open()
         except OSError:
             logger.error(f"unable to parse {input_file}")
             return
@@ -2479,12 +2478,12 @@ class Workflow:
         if job._has_rotated_stdout_err_files:
             error_basename += f".{job._job_output_counter:03d}"
 
-        errfile = os.path.join(self._run_dir, error_basename)
-        if errfile is None or not os.path.isfile(errfile):
+        errfile = str(Path(self._run_dir) / error_basename)
+        if errfile is None or not Path(errfile).is_file():
             return ec
 
         # Read the file first
-        f = open(errfile)
+        f = Path(errfile).open()
         txt = f.read()
         f.close()
 
@@ -2860,7 +2859,7 @@ class Workflow:
             return None
 
         # return the directory component of the path
-        return os.path.dirname(submit_file)
+        return Path(submit_file).parent
 
     def parse_job_sub_file(self, jobid, job_submit_seq):
         """
@@ -2904,9 +2903,11 @@ class Workflow:
         try:
             if my_job._input_file.find(self._original_submit_dir) >= 0:
                 # Path to file includes original submit_dir, let's try to remove it
-                my_job._input_file = os.path.normpath(
-                    my_job._input_file.replace(
-                        (self._original_submit_dir + os.sep), "", 1
+                my_job._input_file = str(
+                    Path(
+                        my_job._input_file.replace(
+                            (self._original_submit_dir + os.sep), "", 1
+                        )
                     )
                 )
         except Exception:
@@ -2915,9 +2916,11 @@ class Workflow:
         try:
             if my_job._output_file.find(self._original_submit_dir) >= 0:
                 # Path to file includes original submit_dir, let's try to remove it
-                my_job._output_file = os.path.normpath(
-                    my_job._output_file.replace(
-                        (self._original_submit_dir + os.sep), "", 1
+                my_job._output_file = str(
+                    Path(
+                        my_job._output_file.replace(
+                            (self._original_submit_dir + os.sep), "", 1
+                        )
                     )
                 )
         except Exception:
@@ -2927,9 +2930,11 @@ class Workflow:
         try:
             if my_job._error_file.find(self._original_submit_dir) >= 0:
                 # Path to file includes original submit_dir, let's try to remove it
-                my_job._error_file = os.path.normpath(
-                    my_job._error_file.replace(
-                        (self._original_submit_dir + os.sep), "", 1
+                my_job._error_file = str(
+                    Path(
+                        my_job._error_file.replace(
+                            (self._original_submit_dir + os.sep), "", 1
+                        )
                     )
                 )
         except Exception:
@@ -2986,24 +2991,24 @@ class Workflow:
             return None
 
         # Got it!
-        my_dagman_out = os.path.normpath(my_dagman_out)
+        my_dagman_out = str(Path(my_dagman_out))
 
         if my_dagman_out.find(self._original_submit_dir) >= 0:
             # Path to new dagman.out file includes original submit_dir, let's try to change it
-            my_dagman_out = os.path.normpath(
-                my_dagman_out.replace((self._original_submit_dir + os.sep), "", 1)
+            my_dagman_out = str(
+                Path(my_dagman_out.replace((self._original_submit_dir + os.sep), "", 1))
             )
             # Join with current run directory
-            my_dagman_out = os.path.join(self._run_dir, my_dagman_out)
+            my_dagman_out = str(Path(self._run_dir) / my_dagman_out)
 
         #        try:
-        #            my_dagman_out = os.path.relpath(my_dagman_out, self._original_submit_dir)
+        #            my_dagman_out = Path(my_dagman_out).relative_to(self._original_submit_dir)
         #        except Exception:
         #            pass
 
         # Split filename into dir and base names
-        my_dagman_dir = os.path.dirname(my_dagman_out)
-        my_dagman_file = os.path.basename(my_dagman_out)
+        my_dagman_dir = Path(my_dagman_out).parent
+        my_dagman_file = Path(my_dagman_out).name
 
         if wf_retries is None:
             logger.warning(
@@ -3036,13 +3041,13 @@ class Workflow:
         my_retry_dir = my_dagman_dir + f".{my_retry:03d}"
 
         # If directory doesn't exist, let's change to rescue mode
-        if not os.path.isdir(my_retry_dir):
+        if not Path(my_retry_dir).is_dir():
             logger.debug(
                 f"sub-workflow directory {my_retry_dir} does not exist, shifting to rescue mode..."
             )
             my_retry_dir = my_dagman_dir + ".000"
 
-            if not os.path.isdir(my_retry_dir):
+            if not Path(my_retry_dir).is_dir():
                 # Still not able to find it, output warning message
                 logger.warning(
                     f"sub-workflow directory {my_retry_dir} does not exist! Skipping this sub-workflow..."
@@ -3050,7 +3055,7 @@ class Workflow:
                 return None
 
         # Found sub-workflow directory, let's compose the final path to the new dagman.out file...
-        return os.path.join(my_retry_dir, my_dagman_file)
+        return str(Path(my_retry_dir) / my_dagman_file)
 
     def set_dagman_version(self, major, minor, patch):
         """

--- a/packages/pegasus-python/src/Pegasus/monitoring/workflow.py
+++ b/packages/pegasus-python/src/Pegasus/monitoring/workflow.py
@@ -1056,14 +1056,16 @@ class Workflow:
 
         if "submit_dir" in wfparams:
             self._submit_dir = wfparams["submit_dir"]
-            self._original_submit_dir = str(Path(wfparams["submit_dir"]))
+            self._original_submit_dir = os.path.normpath(wfparams["submit_dir"])
         else:
             # Use "run" if "submit_dir" not found
             if "run" in wfparams:
                 self._submit_dir = wfparams["run"]
             # Use "jsd" if "submit_dir" is not found
             if "jsd" in wfparams:
-                self._original_submit_dir = Path(str(Path(wfparams["jsd"]))).parent
+                self._original_submit_dir = str(
+                    Path(os.path.normpath(wfparams["jsd"])).parent
+                )
 
         self._fixed_addon_attrs["submit__dir"] = self._submit_dir
 
@@ -2903,11 +2905,9 @@ class Workflow:
         try:
             if my_job._input_file.find(self._original_submit_dir) >= 0:
                 # Path to file includes original submit_dir, let's try to remove it
-                my_job._input_file = str(
-                    Path(
-                        my_job._input_file.replace(
-                            (self._original_submit_dir + os.sep), "", 1
-                        )
+                my_job._input_file = os.path.normpath(
+                    my_job._input_file.replace(
+                        (self._original_submit_dir + os.sep), "", 1
                     )
                 )
         except Exception:
@@ -2916,11 +2916,9 @@ class Workflow:
         try:
             if my_job._output_file.find(self._original_submit_dir) >= 0:
                 # Path to file includes original submit_dir, let's try to remove it
-                my_job._output_file = str(
-                    Path(
-                        my_job._output_file.replace(
-                            (self._original_submit_dir + os.sep), "", 1
-                        )
+                my_job._output_file = os.path.normpath(
+                    my_job._output_file.replace(
+                        (self._original_submit_dir + os.sep), "", 1
                     )
                 )
         except Exception:
@@ -2930,11 +2928,9 @@ class Workflow:
         try:
             if my_job._error_file.find(self._original_submit_dir) >= 0:
                 # Path to file includes original submit_dir, let's try to remove it
-                my_job._error_file = str(
-                    Path(
-                        my_job._error_file.replace(
-                            (self._original_submit_dir + os.sep), "", 1
-                        )
+                my_job._error_file = os.path.normpath(
+                    my_job._error_file.replace(
+                        (self._original_submit_dir + os.sep), "", 1
                     )
                 )
         except Exception:
@@ -2991,12 +2987,12 @@ class Workflow:
             return None
 
         # Got it!
-        my_dagman_out = str(Path(my_dagman_out))
+        my_dagman_out = os.path.normpath(my_dagman_out)
 
         if my_dagman_out.find(self._original_submit_dir) >= 0:
             # Path to new dagman.out file includes original submit_dir, let's try to change it
-            my_dagman_out = str(
-                Path(my_dagman_out.replace((self._original_submit_dir + os.sep), "", 1))
+            my_dagman_out = os.path.normpath(
+                my_dagman_out.replace((self._original_submit_dir + os.sep), "", 1)
             )
             # Join with current run directory
             my_dagman_out = str(Path(self._run_dir) / my_dagman_out)

--- a/packages/pegasus-python/src/Pegasus/netlogger/configobj.py
+++ b/packages/pegasus-python/src/Pegasus/netlogger/configobj.py
@@ -20,6 +20,7 @@
 import os
 import re
 import sys
+from pathlib import Path
 from warnings import warn
 
 INTP_VER = sys.version_info[:2]
@@ -1258,8 +1259,8 @@ class ConfigObj(Section):
     def _load(self, infile, configspec):
         if isinstance(infile, str):
             self.filename = infile
-            if os.path.isfile(infile):
-                h = open(infile, "rb")
+            if Path(infile).is_file():
+                h = Path(infile).open("rb")
                 infile = h.read() or []
                 h.close()
             elif self.file_error:
@@ -1270,7 +1271,7 @@ class ConfigObj(Section):
                 if self.create_empty:
                     # this is a good test that the filename specified
                     # isn't impossible - like on a non-existent device
-                    h = open(infile, "w")
+                    h = Path(infile).open("w")
                     h.write("")
                     h.close()
                 infile = []
@@ -2146,7 +2147,7 @@ class ConfigObj(Section):
         if outfile is not None:
             outfile.write(output)
         else:
-            h = open(self.filename, "wb")
+            h = Path(self.filename).open("wb")
             h.write(output)
             h.close()
         return None

--- a/packages/pegasus-python/src/Pegasus/netlogger/nllog.py
+++ b/packages/pegasus-python/src/Pegasus/netlogger/nllog.py
@@ -12,6 +12,7 @@ import sys
 import time
 import traceback
 import types
+from pathlib import Path
 
 from Pegasus.netlogger import nlapi
 from Pegasus.netlogger.nlapi import Level
@@ -99,10 +100,10 @@ def _modlist(path):
     """
     if path == "/":
         return []
-    head, tail = os.path.split(path)
+    head, tail = (str(Path(path).parent), Path(path).name)
     # ignore python extensions
     if tail.endswith(".py") or tail.endswith(".pyc"):
-        tail = os.path.splitext(tail)[0]
+        tail = Path(tail).stem
     # stop if at top of source tree
     if tail in ("netlogger", "scripts"):
         return []
@@ -335,7 +336,7 @@ def profile(func):
 
     if func.__module__ == "__main__":
         f = func.__globals__["__file__"] or "unknown"
-        event = f"{os.path.splitext(os.path.basename(f))[0]}"
+        event = f"{Path(f).stem}"
         log = _logger("script")
         log.set_meta(file=f, pid=os.getpid(), ppid=os.getppid(), gpid=os.getgid())
     else:
@@ -367,7 +368,7 @@ def profile_result(func):
 
     if func.__module__ == "__main__":
         f = func.__globals__["__file__"] or "unknown"
-        event = f"{os.path.splitext(os.path.basename(f))[0]}"
+        event = f"{Path(f).stem}"
         log = _logger("script")
         log.set_meta(file=f, pid=os.getpid(), ppid=os.getppid(), gpid=os.getgid())
     else:

--- a/packages/pegasus-python/src/Pegasus/netlogger/util.py
+++ b/packages/pegasus-python/src/Pegasus/netlogger/util.py
@@ -4,7 +4,6 @@ Utility functions for NetLogger modules and command-line programs
 
 __rcsid__ = "$Id: util.py 27069 2011-02-08 20:09:10Z dang $"
 __author__ = "Dan Gunter (dkgunter (at) lbl.gov)"
-import glob
 import os
 import queue
 import re
@@ -14,6 +13,7 @@ import time
 import traceback
 from copy import copy
 from optparse import Option, OptionParser, OptionValueError, make_option
+from pathlib import Path
 
 #
 import Pegasus.netlogger
@@ -53,7 +53,7 @@ MAGICDATE_EXAMPLES = ", ".join(
     )
 )
 
-DATA_DIR = os.path.join(os.path.dirname(Pegasus.netlogger.__file__), "data")
+DATA_DIR = str(Path(Path(Pegasus.netlogger.__file__).parent) / "data")
 
 ## Exceptions
 
@@ -293,13 +293,11 @@ def mostRecentFile(dir, file_pattern, after_time=None):
     the same modification time.
 
     """
-    if not os.path.isdir(dir):
+    if not Path(dir).is_dir():
         return []
-    search_path = os.path.join(dir, file_pattern)
     # make a sortable list of filenames and modification times
     timed_files = [
-        (os.stat_result(os.stat(fname)).st_mtime, fname)
-        for fname in glob.glob(search_path)
+        (fname.stat().st_mtime, str(fname)) for fname in Path(dir).glob(file_pattern)
     ]
     # if the list is empty, stop
     if not timed_files:
@@ -397,7 +395,8 @@ def daemonize(log=None, root_log=None, close_fds=True):
 
 def _getNumberedFiles(path):
     result = []
-    for filename in glob.glob(path + ".*"):
+    for filename in Path(path).parent.glob(Path(path).name + ".*"):
+        filename = str(filename)
         try:
             name, ext = filename.rsplit(".", 1)
             n = int(ext)
@@ -553,12 +552,12 @@ class NullFile:
 
 def rm_rf(d):
     """Remove directories and their contents, recursively."""
-    for path in (os.path.join(d, f) for f in os.listdir(d)):
-        if os.path.isdir(path):
-            rm_rf(path)
+    for path in Path(d).iterdir():
+        if path.is_dir():
+            rm_rf(str(path))
         else:
-            os.unlink(path)
-    os.rmdir(d)
+            path.unlink()
+    Path(d).rmdir()
 
 
 class IncConfigObj(configobj.ConfigObj):
@@ -582,7 +581,7 @@ class IncConfigObj(configobj.ConfigObj):
             f.seek(0)  # rewind to start of file
         else:
             f = file(infile)
-        dir_ = os.path.dirname(f.name)
+        dir_ = Path(f.name).parent
         # Create list of lines that includes the included files
         lines = []
         file_lines = []  # tuple: (filename, linenum)
@@ -597,7 +596,7 @@ class IncConfigObj(configobj.ConfigObj):
                 inc_path = filter(None, m.groups()[1:])[0]
                 # open the corresponding file
                 if not inc_path[0] == "/":
-                    inc_path = os.path.join(dir_, inc_path)
+                    inc_path = str(Path(dir_) / inc_path)
                 try:
                     inc_file = file(inc_path)
                 except OSError:
@@ -795,7 +794,7 @@ def getProgFromFile(f):
     """Get program name from __file__."""
     if f.endswith(".py"):
         f = f[:-3]
-    return os.path.basename(f)
+    return Path(f).name
 
 
 # Python 2.4-friendly uuid generator

--- a/packages/pegasus-python/src/Pegasus/service/dashboard/views.py
+++ b/packages/pegasus-python/src/Pegasus/service/dashboard/views.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 
 from flask import g, redirect, render_template, request, send_from_directory, url_for
@@ -580,9 +581,9 @@ def file_list(username, root_wf_id, wf_id, path=""):
 
             for entry in Path(dest).iterdir():
                 if entry.is_dir():
-                    folders["dirs"].append(str(Path(str(Path(path) / entry.name))))
+                    folders["dirs"].append(os.path.normpath(Path(path) / entry.name))
                 else:
-                    folders["files"].append(str(Path(str(Path(path) / entry.name))))
+                    folders["files"].append(os.path.normpath(Path(path) / entry.name))
 
             return serialize(folders), 200, {"Content-Type": "application/json"}
 

--- a/packages/pegasus-python/src/Pegasus/service/dashboard/views.py
+++ b/packages/pegasus-python/src/Pegasus/service/dashboard/views.py
@@ -1,5 +1,5 @@
 import logging
-import os
+from pathlib import Path
 
 from flask import g, redirect, render_template, request, send_from_directory, url_for
 from sqlalchemy.orm.exc import NoResultFound
@@ -539,7 +539,7 @@ def file_browser(username, root_wf_id, wf_id):
         details = dashboard.get_workflow_details(wf_id)
         submit_dir = details.submit_dir
 
-        if os.path.isdir(submit_dir):
+        if Path(submit_dir).is_dir():
             init_file = request.args.get("init_file", None)
             return render_template(
                 "file-browser.html",
@@ -570,19 +570,19 @@ def file_list(username, root_wf_id, wf_id, path=""):
         details = dashboard.get_workflow_details(wf_id)
         submit_dir = details.submit_dir
 
-        if os.path.isdir(submit_dir):
-            dest = os.path.join(submit_dir, path)
+        if Path(submit_dir).is_dir():
+            dest = str(Path(submit_dir) / path)
 
-            if os.path.isfile(dest):
+            if Path(dest).is_file():
                 return "", 204
 
             folders = {"dirs": [], "files": []}
 
-            for entry in os.listdir(dest):
-                if os.path.isdir(os.path.join(dest, entry)):
-                    folders["dirs"].append(os.path.normpath(os.path.join(path, entry)))
+            for entry in Path(dest).iterdir():
+                if entry.is_dir():
+                    folders["dirs"].append(str(Path(str(Path(path) / entry.name))))
                 else:
-                    folders["files"].append(os.path.normpath(os.path.join(path, entry)))
+                    folders["files"].append(str(Path(str(Path(path) / entry.name))))
 
             return serialize(folders), 200, {"Content-Type": "application/json"}
 
@@ -608,8 +608,8 @@ def file_view(username, root_wf_id, wf_id, path):
         details = dashboard.get_workflow_details(wf_id)
         submit_dir = details.submit_dir
 
-        file_path = os.path.join(submit_dir, path)
-        if not os.path.isfile(file_path):
+        file_path = str(Path(submit_dir) / path)
+        if not Path(file_path).is_file():
             return "File not found", 404
 
         return send_from_directory(submit_dir, path)

--- a/packages/pegasus-python/src/Pegasus/service/ensembles/__init__.py
+++ b/packages/pegasus-python/src/Pegasus/service/ensembles/__init__.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 from flask import Flask
 
@@ -8,8 +8,8 @@ emapp = Flask(__name__)
 emapp.config.from_object("Pegasus.service.defaults")
 
 # Load user configuration
-conf = os.path.expanduser("~/.pegasus/service.py")
-if os.path.isfile(conf):
+conf = Path("~/.pegasus/service.py").expanduser()
+if Path(conf).is_file():
     emapp.config.from_pyfile(conf)
 del conf
 

--- a/packages/pegasus-python/src/Pegasus/service/ensembles/bundle.py
+++ b/packages/pegasus-python/src/Pegasus/service/ensembles/bundle.py
@@ -1,5 +1,5 @@
-import os
 import zipfile
+from pathlib import Path
 
 from Pegasus.tools import properties
 
@@ -14,7 +14,7 @@ class Bundle:
     def __init__(self, filename):
         self.filename = filename
 
-        if not os.path.isfile(filename):
+        if not Path(filename).is_file():
             raise BundleException("No such file")
 
         # Verify that the bundle is a valid zip file
@@ -51,7 +51,7 @@ class Bundle:
         if filename is None:
             return
 
-        if not self.contains(filename) and not os.path.isfile(filename):
+        if not self.contains(filename) and not Path(filename).is_file():
             raise BundleException(f"Invalid {propname}: No such file: {filename}")
 
     def verify(self):

--- a/packages/pegasus-python/src/Pegasus/service/ensembles/commands.py
+++ b/packages/pegasus-python/src/Pegasus/service/ensembles/commands.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 import time
+from pathlib import Path
 from urllib import parse as urlparse
 
 import requests
@@ -188,18 +189,18 @@ class CreateCommand(EnsembleClientCommand):
 
 def pathfind(command):
     def isexe(fn):
-        return os.path.isfile(fn) and os.access(fn, os.X_OK)
+        return Path(fn).is_file() and os.access(fn, os.X_OK)
 
-    path, exe = os.path.split(command)
+    path = "" if Path(command).parent == Path() else str(Path(command).parent)
 
     if path:
         if isexe(command):
-            return os.path.abspath(command)
+            return Path(command).resolve()
         return None
 
     # Search PATH
     for path in os.environ["PATH"].split(os.pathsep):
-        fn = os.path.join(path, command)
+        fn = str(Path(path) / command)
         if isexe(fn):
             return fn
 
@@ -247,7 +248,7 @@ class SubmitCommand(EnsembleClientCommand):
         data = {
             "name": workflow,
             "priority": o.priority,
-            "basedir": os.getcwd(),
+            "basedir": Path.cwd(),
             "plan_command": command,
         }
 

--- a/packages/pegasus-python/src/Pegasus/service/ensembles/manager.py
+++ b/packages/pegasus-python/src/Pegasus/service/ensembles/manager.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import threading
 import time
+from pathlib import Path
 
 from sqlalchemy import select
 from sqlalchemy.orm.exc import NoResultFound
@@ -27,8 +28,8 @@ def pathfind(exe):
     PATH = os.getenv("PATH", "/bin:/usr/bin:/usr/local/bin")
     PATH = PATH.split(":")
     for prefix in PATH:
-        exepath = os.path.join(prefix, exe)
-        if os.path.isfile(exepath):
+        exepath = str(Path(prefix) / exe)
+        if Path(exepath).is_file():
             return exepath
     raise EMError(f"{exe} not found on PATH")
 
@@ -41,19 +42,19 @@ def get_bin(name, exe):
     HOME = os.getenv(name, emapp.config.get(name, None))
 
     if HOME is not None:
-        if not os.path.isdir(HOME):
+        if not Path(HOME).is_dir():
             raise EMError(f"{name} is not a directory: {HOME}")
-        BIN = os.path.join(HOME, "bin")
-        if not os.path.isdir(BIN):
+        BIN = str(Path(HOME) / "bin")
+        if not Path(BIN).is_dir():
             raise EMError(f"{name}/bin is not a directory: {BIN}")
-        exepath = os.path.join(BIN, exe)
+        exepath = str(Path(BIN) / exe)
 
     exepath = exepath or pathfind(exe)
 
-    if not os.path.isfile(exepath):
+    if not Path(exepath).is_file():
         raise EMError(f"{exe} not found: {exepath}")
 
-    return os.path.dirname(exepath)
+    return Path(exepath).parent
 
 
 def get_pegasus_bin():
@@ -86,7 +87,7 @@ def get_script_env():
 
 def runscript(script, cwd=None, env=None):
     # Make sure the cwd is OK
-    if cwd is not None and not os.path.isdir(cwd):
+    if cwd is not None and not Path(cwd).is_dir():
         raise EMError(f"Working directory does not exist: {cwd}")
 
     if env is None:
@@ -105,7 +106,7 @@ def forkscript(script, pidfile=None, cwd=None, env=None):
     # interpreter so that we don't have to call wait() on it
 
     # Make sure the cwd is OK
-    if cwd is not None and not os.path.isdir(cwd):
+    if cwd is not None and not Path(cwd).is_dir():
         raise EMError(f"Working directory does not exist: {cwd}")
 
     if env is None:
@@ -115,7 +116,7 @@ def forkscript(script, pidfile=None, cwd=None, env=None):
     # something wrong with the pidfile
     if pidfile is not None:
         try:
-            open(pidfile, "w").close()
+            Path(pidfile).open("w").close()
         except Exception:
             raise EMError(f"Unable to write pidfile: {pidfile}")
 
@@ -130,7 +131,7 @@ def forkscript(script, pidfile=None, cwd=None, env=None):
             os._exit(255)
 
         if pidfile is not None:
-            f = open(pidfile, "w")
+            f = Path(pidfile).open("w")
             f.write(f"{pid2:d}\n")
             f.close()
 
@@ -156,7 +157,7 @@ class WorkflowProcessor:
         resultfile = w.get_resultfile()
         plan_command = w.get_plan_command()
 
-        if os.path.isfile(pidfile) and self.planning():
+        if Path(pidfile).is_file() and self.planning():
             raise EMError("Planner already running")
 
         # When we re-plan, we need to remove all the old
@@ -164,8 +165,8 @@ class WorkflowProcessor:
         # confused.
         files = [runfile, resultfile, pidfile]
         for f in files:
-            if os.path.isfile(f):
-                os.remove(f)
+            if Path(f).is_file():
+                Path(f).unlink()
 
         script = f"({plan_command}) 2>&1 | tee -a {logfile} | grep pegasus-run >{runfile} ; /bin/echo $? >{resultfile}"
         forkscript(script, cwd=basedir, pidfile=pidfile, env=get_script_env())
@@ -174,10 +175,10 @@ class WorkflowProcessor:
         "Check pidfile to see if the planner is still running"
         pidfile = self.workflow.get_pidfile()
 
-        if not os.path.exists(pidfile):
+        if not Path(pidfile).exists():
             raise EMError("pidfile missing")
 
-        pid = int(open(pidfile).read())
+        pid = int(Path(pidfile).open().read())
 
         try:
             os.kill(pid, 0)
@@ -194,10 +195,10 @@ class WorkflowProcessor:
         "Check to see if planning was successful"
         resultfile = self.workflow.get_resultfile()
 
-        if not os.path.exists(resultfile):
+        if not Path(resultfile).exists():
             raise EMError(f"Result file not found: {resultfile}")
 
-        exitcode = int(open(resultfile).read())
+        exitcode = int(Path(resultfile).open().read())
 
         if exitcode != 0:
             return False
@@ -214,12 +215,12 @@ class WorkflowProcessor:
         "Get the workflow submitdir from the workflow log"
         logfile = self.workflow.get_runfile()
 
-        if not os.path.isfile(logfile):
+        if not Path(logfile).is_file():
             raise EMError(f"Workflow run file not found: {logfile}")
 
         submitdir = None
 
-        f = open(logfile)
+        f = Path(logfile).open()
         try:
             for line in f:
                 if line.startswith("pegasus-run"):
@@ -236,12 +237,12 @@ class WorkflowProcessor:
         "Get the workflow UUID from the braindump file"
         submitdir = self.find_submitdir()
 
-        braindump_file_path = os.path.join(submitdir, "braindump.yml")
+        braindump_file_path = str(Path(submitdir) / "braindump.yml")
 
-        if not os.path.isfile(braindump_file_path):
+        if not Path(braindump_file_path).is_file():
             raise EMError("braindump.yml not found")
 
-        with open(braindump_file_path) as f:
+        with Path(braindump_file_path).open() as f:
             bd = braindump.load(f)
 
         if bd.wf_uuid is None:
@@ -256,7 +257,7 @@ class WorkflowProcessor:
         if submitdir is None:
             raise EMError("Workflow submitdir not set")
 
-        if not os.path.isdir(submitdir):
+        if not Path(submitdir).is_dir():
             raise EMError(f"Workflow submit dir does not exist: {submitdir}")
 
         logfile = self.workflow.get_logfile()
@@ -502,9 +503,9 @@ class EnsembleProcessor:
 
     def run(self):
         edir = self.ensemble.get_localdir()
-        if not os.path.isdir(edir):
+        if not Path(edir).is_dir():
             log.info(f"Creating ensemble directory: {edir}")
-            os.makedirs(edir, 0o700)
+            Path(edir).mkdir(0o700, parents=True)
 
         log.info(f"Processing {len(self.workflows):d} ensemble workflows...")
         for w in self.workflows:

--- a/packages/pegasus-python/src/Pegasus/service/ensembles/trigger.py
+++ b/packages/pegasus-python/src/Pegasus/service/ensembles/trigger.py
@@ -6,7 +6,6 @@ import shutil
 import subprocess
 import threading
 import time
-from glob import glob
 from pathlib import Path
 
 from Pegasus import user
@@ -345,7 +344,7 @@ class FilePatternTrigger(TriggerThread):
             processed_dir = parent_dir / "processed"
             processed_dir.mkdir(parents=False, exist_ok=True)
 
-            for match in glob(pattern):
+            for match in Path(pattern).parent.glob(Path(pattern).name):
                 # move file into processed dir and add that path
                 f = Path(match).resolve()
                 dst = processed_dir / f.name

--- a/packages/pegasus-python/src/Pegasus/service/ensembles/views.py
+++ b/packages/pegasus-python/src/Pegasus/service/ensembles/views.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import re
 import subprocess
 from pathlib import Path
@@ -198,14 +197,14 @@ def analyze(workflow):
     yield f"Plan command is: {w.plan_command}\n"
 
     logfile = w.get_logfile()
-    if os.path.isfile(logfile):
+    if Path(logfile).is_file():
         yield "Workflow log:\n"
-        for line in open(w.get_logfile(), "rb"):
+        for line in Path(w.get_logfile()).open("rb"):
             yield f"LOG: {line.decode()}"
     else:
         yield "No workflow log available\n"
 
-    if w.submitdir is None or not os.path.isdir(w.submitdir):
+    if w.submitdir is None or not Path(w.submitdir).is_dir():
         yield "No submit directory available\n"
     else:
         yield "pegasus-analyzer output is:\n"

--- a/packages/pegasus-python/src/Pegasus/service/lifecycle.py
+++ b/packages/pegasus-python/src/Pegasus/service/lifecycle.py
@@ -2,6 +2,7 @@ import logging
 import os
 import uuid
 from datetime import datetime
+from pathlib import Path
 
 from flask import Response, abort, current_app, g, make_response, request, url_for
 
@@ -150,10 +151,10 @@ def authorization():
     # Does the user have a Pegasus home directory?
     user_pegasus_dir = user_info.get_pegasus_dir()
 
-    if not os.path.isdir(user_pegasus_dir):
+    if not Path(user_pegasus_dir).is_dir():
         log.info("User's pegasus directory does not exist. Creating one...")
         try:
-            os.makedirs(user_pegasus_dir, mode=0o744)
+            Path(user_pegasus_dir).mkdir(mode=0o744, parents=True)
         except OSError:
             log.info("Invalid Permissions: Could not create user's pegasus directory.")
             return make_response("Could not find user's Pegasus directory", 404)

--- a/packages/pegasus-python/src/Pegasus/service/server.py
+++ b/packages/pegasus-python/src/Pegasus/service/server.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 
 import click
 import flask
@@ -32,9 +33,9 @@ def run(host="localhost", port=5000, debug=True, verbose=logging.INFO, **kwargs)
         log.info("Using non-standard URL prefix: %s", pegasus_service_url_prefix)
         app.config["APPLICATION_ROOT"] = pegasus_service_url_prefix
 
-    pegasusdir = os.path.expanduser("~/.pegasus")
-    if not os.path.isdir(pegasusdir):
-        os.makedirs(pegasusdir, mode=0o744)
+    pegasusdir = Path("~/.pegasus").expanduser()
+    if not Path(pegasusdir).is_dir():
+        Path(pegasusdir).mkdir(mode=0o744, parents=True)
 
     cert = app.config.get("CERTIFICATE", None)
     pkey = app.config.get("PRIVATE_KEY", None)
@@ -83,8 +84,8 @@ def run(host="localhost", port=5000, debug=True, verbose=logging.INFO, **kwargs)
 
 def _load_user_config(app):
     # Load user configuration
-    conf = os.path.expanduser("~/.pegasus/service.py")
-    if os.path.isfile(conf):
+    conf = Path("~/.pegasus/service.py").expanduser()
+    if Path(conf).is_file():
         app.config.from_pyfile(conf)
 
 

--- a/packages/pegasus-python/src/Pegasus/submitdir.py
+++ b/packages/pegasus-python/src/Pegasus/submitdir.py
@@ -6,12 +6,10 @@ attach, and detach submit directories from the Pegasus master database. These
 operations are exposed via the ``pegasus-submitdir`` CLI tool.
 """
 
-import glob
 import logging
-import os
 import shutil
 import tarfile
-from os.path import expanduser
+from pathlib import Path
 
 from sqlalchemy import select
 
@@ -122,10 +120,10 @@ class WorkflowDatabase:
 
 class SubmitDir:
     def __init__(self, submitdir, raise_err=True):
-        self.submitdir = os.path.abspath(submitdir)
+        self.submitdir = Path(submitdir).resolve()
         self.submitdir_exists = True
 
-        if not os.path.isdir(submitdir):
+        if not Path(submitdir).is_dir():
             self.submitdir_exists = False
 
             if raise_err is False:
@@ -133,19 +131,19 @@ class SubmitDir:
 
             raise SubmitDirException(f"Invalid submit dir: {submitdir}")
 
-        self.braindump_file = os.path.join(self.submitdir, "braindump.yml")
-        if not os.path.isfile(self.braindump_file):
-            self.braindump_file = os.path.join(self.submitdir, "braindump.txt")
+        self.braindump_file = str(Path(self.submitdir) / "braindump.yml")
+        if not Path(self.braindump_file).is_file():
+            self.braindump_file = str(Path(self.submitdir) / "braindump.txt")
 
         # Read the braindump file
-        self.braindump = utils.slurp_braindb(os.path.join(self.submitdir))
+        self.braindump = utils.slurp_braindb(str(Path(self.submitdir)))
 
         # Read some attributes from braindump file
         self.wf_uuid = self.braindump["wf_uuid"]
         self.root_wf_uuid = self.braindump["root_wf_uuid"]
         self.user = self.braindump["user"]
 
-        self.archname = os.path.join(self.submitdir, "archive.tar.gz")
+        self.archname = str(Path(self.submitdir) / "archive.tar.gz")
 
     def is_subworkflow(self):
         "Check to see if this workflow is a subworkflow"
@@ -153,7 +151,7 @@ class SubmitDir:
 
     def is_archived(self):
         "A submit dir is archived if the archive file exists"
-        return os.path.isfile(self.archname)
+        return Path(self.archname).is_file()
 
     def extract(self):
         "Extract files from an archived submit dir"
@@ -177,7 +175,7 @@ class SubmitDir:
         tar.close()
 
         # Remove the tar file
-        os.remove(self.archname)
+        Path(self.archname).unlink()
 
         # Commit the workflow changes
         mdbsession.commit()
@@ -203,15 +201,15 @@ class SubmitDir:
 
         # We use a temporary file so that we can determine if the archive step
         # completed successfully later
-        tmparchname = os.path.join(self.submitdir, "archive.tmp.tar.gz")
+        tmparchname = str(Path(self.submitdir) / "archive.tmp.tar.gz")
 
         # We use a lock file to determine if cleanup is complete
-        lockfile = os.path.join(self.submitdir, "archive.cleanup.lock")
+        lockfile = str(Path(self.submitdir) / "archive.cleanup.lock")
 
         # If a previous archive was partially completed, then remove the
         # temporary file that was created
-        if os.path.exists(tmparchname):
-            os.unlink(tmparchname)
+        if Path(tmparchname).exists():
+            Path(tmparchname).unlink()
 
         # Exclude the temporary archive name so we don't add it to itself
         exclude.add(tmparchname)
@@ -225,25 +223,26 @@ class SubmitDir:
         # Ignore monitord files. This is needed so that tools like pegasus-statistics
         # will consider the workflow to be complete
         for name in ["monitord.started", "monitord.done", "monitord.log"]:
-            exclude.add(os.path.join(self.submitdir, name))
+            exclude.add(str(Path(self.submitdir) / name))
 
         # Exclude stampede db
-        for db in glob.glob(os.path.join(self.submitdir, "*.stampede.db")):
-            exclude.add(db)
+        for db in Path(self.submitdir).glob("*.stampede.db"):
+            exclude.add(str(db))
 
         # Exclude properties file
-        for prop in glob.glob(os.path.join(self.submitdir, "pegasus.*.properties")):
-            exclude.add(prop)
+        for prop in Path(self.submitdir).glob("pegasus.*.properties"):
+            exclude.add(str(prop))
 
         # Visit all the files in the submit dir that we want to archive
         def visit(dirpath):
-            for name in os.listdir(dirpath):
-                filepath = os.path.join(dirpath, name)
+            for path in Path(dirpath).iterdir():
+                name = path.name
+                filepath = str(path)
 
                 if filepath not in exclude:
                     yield name, filepath
 
-        if self.is_archived() and not os.path.exists(lockfile):
+        if self.is_archived() and not Path(lockfile).exists():
             raise SubmitDirException("Submit directory already archived")
 
         if not self.is_archived():
@@ -255,10 +254,10 @@ class SubmitDir:
             tar.close()
 
             # This "commits" the archive step
-            os.rename(tmparchname, self.archname)
+            Path(tmparchname).rename(self.archname)
 
         # Touch lockfile
-        open(lockfile, "w").close()
+        Path(lockfile).open("w").close()
 
         # Remove the files and directories
         # We do this here, instead of doing it in the loop above
@@ -266,13 +265,13 @@ class SubmitDir:
         # the archive before we start removing files
         print("Removing files...")
         for name, path in visit(self.submitdir):
-            if os.path.isfile(path) or os.path.islink(path):
-                os.remove(path)
+            if Path(path).is_file() or Path(path).is_symlink():
+                Path(path).unlink()
             else:
                 shutil.rmtree(path)
 
         # This "commits" the file removal
-        os.unlink(lockfile)
+        Path(lockfile).unlink()
 
         # Commit the workflow changes
         mdbsession.commit()
@@ -281,15 +280,15 @@ class SubmitDir:
     def move(self, dest):
         "Move this submit directory to dest"
 
-        dest = os.path.abspath(dest)
+        dest = Path(dest).resolve()
 
-        if os.path.isfile(dest):
+        if Path(dest).is_file():
             raise SubmitDirException(f"Destination is a file: {dest}")
 
-        if os.path.isdir(dest):
-            if os.path.exists(os.path.join(dest, "braindump.txt")):
+        if Path(dest).is_dir():
+            if Path(str(Path(dest) / "braindump.txt")).exists():
                 raise SubmitDirException(f"Destination is a submit dir: {dest}")
-            dest = os.path.join(dest, os.path.basename(self.submitdir))
+            dest = str(Path(dest) / Path(self.submitdir).name)
 
         # Verify that we aren't trying to move a subworkflow
         if self.is_subworkflow():
@@ -349,8 +348,8 @@ class SubmitDir:
 
         # Set new paths in the braindump file
         self.braindump["submit_dir"] = dest
-        self.braindump["basedir"] = os.path.dirname(dest)
-        utils.write_braindump(os.path.join(dest, "braindump.txt"), self.braindump)
+        self.braindump["basedir"] = Path(dest).parent
+        utils.write_braindump(str(Path(dest) / "braindump.txt"), self.braindump)
 
         # Note that we do not need to update the properties file even though it
         # might contain DB URLs because it cannot contain a DB URL with the submit
@@ -534,7 +533,7 @@ class SubmitDir:
 
         else:
             # Connect to master database
-            home = expanduser("~")
+            home = Path("~").expanduser()
             mdbsession = connection.connect(
                 f"sqlite:///{home}/.pegasus/workflow.db",
                 db_type=connection.DBType.MASTER,

--- a/packages/pegasus-python/src/Pegasus/tools/kickstart_parser.py
+++ b/packages/pegasus-python/src/Pegasus/tools/kickstart_parser.py
@@ -11,6 +11,7 @@ import re
 import sys
 import traceback
 from enum import Enum
+from pathlib import Path
 from pprint import pprint
 from xml.parsers import expat
 
@@ -73,7 +74,7 @@ class Parser:
         This function opens a kickstart output file.
         """
         try:
-            self._fh = open(self._kickstart_output_file)
+            self._fh = Path(self._kickstart_output_file).open()
         except Exception:
             # Error opening file
             self._fh = None

--- a/packages/pegasus-python/src/Pegasus/tools/properties.py
+++ b/packages/pegasus-python/src/Pegasus/tools/properties.py
@@ -16,6 +16,7 @@ import re
 import sys
 import tempfile
 import time
+from pathlib import Path
 
 ##
 #  Copyright 2007-2010 University Of Southern California
@@ -61,7 +62,7 @@ else:
 system["os.name"] = os.uname()[0]
 system["os.version"] = os.uname()[2]
 system["os.arch"] = os.uname()[4]
-system["user.dir"] = os.getcwd()
+system["user.dir"] = Path.cwd()
 if "HOME" in os.environ:
     system["user.home"] = os.environ["HOME"]
 else:
@@ -140,7 +141,7 @@ def parse_properties(my_file, hashref={}):
     my_save = ""
 
     if isinstance(my_file, str):
-        my_file = open(my_file)
+        my_file = Path(my_file).open()
 
     logger.debug(f"# parsing properties in {my_file}...")
 
@@ -241,7 +242,7 @@ class Properties:
 
         # First, try config_file, highest priority
         if config_file is not None:
-            if os.path.isfile(config_file) and os.access(config_file, os.R_OK):
+            if Path(config_file).is_file() and os.access(config_file, os.R_OK):
                 logger.debug(f"processing properties file {config_file}...")
                 my_config.update(parse_properties(config_file))
                 my_already_loaded = True
@@ -252,7 +253,7 @@ class Properties:
 
         # Second, try rundir_propfile
         if not my_already_loaded and rundir_propfile is not None:
-            if os.path.isfile(rundir_propfile) and os.access(rundir_propfile, os.R_OK):
+            if Path(rundir_propfile).is_file() and os.access(rundir_propfile, os.R_OK):
                 logger.debug(f"processing properties file {rundir_propfile}... ")
                 my_config.update(parse_properties(rundir_propfile))
                 my_already_loaded = True
@@ -264,8 +265,8 @@ class Properties:
         # look for $(HOME)/.pegasusrc
         if not my_already_loaded:
             if "user.home" in system:
-                my_user_propfile = os.path.join(system["user.home"], ".pegasusrc")
-                if os.path.isfile(my_user_propfile) and os.access(
+                my_user_propfile = str(Path(system["user.home"]) / ".pegasusrc")
+                if Path(my_user_propfile).is_file() and os.access(
                     my_user_propfile, os.R_OK
                 ):
                     logger.debug(f"processing properties file {my_user_propfile}... ")
@@ -278,10 +279,10 @@ class Properties:
         # Last chance, look for $(HOME)/.pegasus/pegasus.conf
         if not my_already_loaded:
             if "user.home" in system:
-                my_user_propfile = os.path.join(
-                    system["user.home"], ".pegasus", "pegasus.conf"
+                my_user_propfile = str(
+                    Path(system["user.home"]) / ".pegasus" / "pegasus.conf"
                 )
-                if os.path.isfile(my_user_propfile) and os.access(
+                if Path(my_user_propfile).is_file() and os.access(
                     my_user_propfile, os.R_OK
                 ):
                     logger.debug(f"processing properties file {my_user_propfile}... ")
@@ -380,7 +381,7 @@ class Properties:
             my_file = sys.stdout
         else:
             try:
-                my_file = open(fn, "w")
+                my_file = Path(fn).open("w")
             except Exception:
                 logger.warning(f"error opening {fn} !")
                 return None

--- a/packages/pegasus-python/src/Pegasus/tools/utils.py
+++ b/packages/pegasus-python/src/Pegasus/tools/utils.py
@@ -301,17 +301,17 @@ def create_directory(dir_name, delete_if_exists=False):
     @param delete_if_exists specifies whether to delete the directory if it exists
     """
     if delete_if_exists:
-        if os.path.isdir(dir_name):
+        if Path(dir_name).is_dir():
             logger.warning("Deleting existing directory. Deleting... " + dir_name)
             try:
                 shutil.rmtree(dir_name)
             except Exception:
                 logger.error("Unable to remove existing directory." + dir_name)
                 sys.exit(1)
-    if not os.path.isdir(dir_name):
+    if not Path(dir_name).is_dir():
         logger.info("Creating directory... " + dir_name)
         try:
-            os.mkdir(dir_name)
+            Path(dir_name).mkdir()
         except OSError:
             logger.error("Unable to create directory." + dir_name)
             sys.exit(1)
@@ -328,14 +328,14 @@ def find_exec(program, curdir=False, otherdirs=[]):
     my_path = os.getenv("PATH", "/bin:/usr/bin")
 
     for my_dir in my_path.split(":") + otherdirs:
-        my_file = os.path.join(os.path.expanduser(my_dir), program)
+        my_file = str(Path(Path(my_dir).expanduser()) / program)
         # Test if file is 'executable'
         if os.access(my_file, os.X_OK):
             # Found it!
             return my_file
 
     if curdir:
-        my_file = os.path.join(os.getcwd(), program)
+        my_file = str(Path(Path.cwd()) / program)
         # Test if file is 'executable'
         if os.access(my_file, os.X_OK):
             # Yes!
@@ -348,7 +348,7 @@ def find_exec(program, curdir=False, otherdirs=[]):
 # TODO: Remove, only used in pegasus-submitdir
 def write_braindump(filename, items):
     "This simply writes a dict to the file specified in braindump format"
-    f = open(filename, "w")
+    f = Path(filename).open("w")
     for k in items:
         f.write(f"{k} {items[k]}\n")
     f.close()
@@ -358,7 +358,7 @@ def write_braindump(filename, items):
 def read_braindump(filename):
     "This simply reads a braindump dict from the file specified"
     items = {}
-    f = open(filename)
+    f = Path(filename).open()
     for line in f:
         k, v = line.strip().split(" ", 1)
         k = k.strip()
@@ -377,12 +377,12 @@ def _slurp_braindb(run, brain_alternate=None):
     my_config = {}
 
     if brain_alternate is None:
-        my_braindb = os.path.join(run, "braindump.txt")
+        my_braindb = str(Path(run) / "braindump.txt")
     else:
-        my_braindb = os.path.join(run, brain_alternate)
+        my_braindb = str(Path(run) / brain_alternate)
 
     try:
-        my_file = open(my_braindb)
+        my_file = Path(my_braindb).open()
     except OSError:
         # Error opening file
         return my_config
@@ -505,14 +505,14 @@ def out2log(rundir, outfile):
     """
 
     # Get the basename
-    my_base = os.path.basename(outfile)
+    my_base = Path(outfile).name
     # NEW: Account for rescue DAGs
     my_base = my_base[: my_base.find(".dagman.out")]
     my_base = re_remove_extensions.sub("", my_base)
     # Add .log extension
     my_base = my_base + ".log"
     # Create path
-    my_log = os.path.join(rundir, my_base)
+    my_log = str(Path(rundir) / my_base)
 
     return my_log, my_base
 
@@ -523,7 +523,7 @@ def write_pid_file(pid_filename, ts=int(time.time())):
     the current pid and timestamp.
     """
     try:
-        PIDFILE = open(pid_filename, "w")
+        PIDFILE = Path(pid_filename).open("w")
         PIDFILE.write(f"pid {os.getpid()}\n")
         PIDFILE.write(f"timestamp {isodate(ts)}\n")
     except OSError:
@@ -543,7 +543,7 @@ def pid_running(filename):
     if os.access(filename, os.F_OK):
         try:
             # Open pid file
-            PIDFILE = open(filename)
+            PIDFILE = Path(filename).open()
 
             # Look for pid line
             for line in PIDFILE:
@@ -601,8 +601,8 @@ def monitoring_running(run_dir):
     that pegasus-monitord is still running, or false if it has
     finished (or perhaps it was never started).
     """
-    start_file = os.path.join(run_dir, "monitord.started")
-    done_file = os.path.join(run_dir, "monitord.done")
+    start_file = str(Path(run_dir) / "monitord.started")
+    done_file = str(Path(run_dir) / "monitord.done")
 
     # If monitord finished, it is not running anymore
     if os.access(done_file, os.F_OK):
@@ -627,9 +627,9 @@ def loading_completed(run_dir):
     if monitoring_running(run_dir) is True:
         return False
 
-    start_file = os.path.join(run_dir, "monitord.started")
-    done_file = os.path.join(run_dir, "monitord.done")
-    log_file = os.path.join(run_dir, "monitord.log")
+    start_file = str(Path(run_dir) / "monitord.started")
+    done_file = str(Path(run_dir) / "monitord.done")
+    log_file = str(Path(run_dir) / "monitord.log")
 
     # Both started and done files need to exist...
     if (not os.access(start_file, os.F_OK)) or (not os.access(done_file, os.F_OK)):
@@ -638,7 +638,7 @@ def loading_completed(run_dir):
     # Check monitord.log for loading errors...
     if os.access(log_file, os.F_OK):
         try:
-            LOG = open(log_file)
+            LOG = Path(log_file).open()
             for line in LOG:
                 if line.find("NL-LOAD-ERROR -->") > 0:
                     # Found loading error... event processing was not completed
@@ -695,7 +695,7 @@ def rotate_log_file(source_file):
 
     # Now that we have source_file and dest_file, try to rotate the logs
     try:
-        os.rename(source_file, dest_file)
+        Path(source_file).rename(dest_file)
     except OSError:
         logger.error(f"cannot rename {source_file} to {dest_file}")
         sys.exit(1)
@@ -760,7 +760,7 @@ def truncate_file(source_file):
         return False
 
     try:
-        with open(source_file, "w") as fp:
+        with Path(source_file).open("w") as fp:
             fp.truncate(0)
     except Exception:
         logger.error("Unable to truncate file %s", source_file)
@@ -789,7 +789,7 @@ def make_boolean(value):
 @contextmanager
 def write_table(f, fields, headers=None, widths=None, encoding=None):
     """."""
-    with open(f, "w", encoding=encoding) as writer:
+    with Path(f).open("w", encoding=encoding) as writer:
         if widths is None:
             widths = [len(_) for _ in fields]
 
@@ -829,7 +829,7 @@ def write_table(f, fields, headers=None, widths=None, encoding=None):
 @contextmanager
 def write_csv(f, fields, headers=None, dialect=csv.excel, encoding=None):
     """."""
-    with open(f, "w", encoding=encoding) as csvfile:
+    with Path(f).open("w", encoding=encoding) as csvfile:
         writer = csv.DictWriter(
             csvfile, dialect=dialect, fieldnames=fields, extrasaction="ignore"
         )
@@ -857,13 +857,13 @@ def pegasus_version():
     # is calling out to pegasus-version really the best way to do this?
     pegasus_version = None
     if "PEGASUS_HOME" in os.environ:
-        f = os.path.join(os.environ.get("PEGASUS_HOME"), "bin/pegasus-version")
-        if os.path.isfile(f):
+        f = str(Path(os.environ.get("PEGASUS_HOME")) / "bin/pegasus-version")
+        if Path(f).is_file():
             pegasus_version = f
 
     if not pegasus_version:
-        f = os.path.join(os.path.dirname(sys.argv[0]), "pegasus-version")
-        if os.path.isfile(f):
+        f = str(Path(Path(sys.argv[0]).parent) / "pegasus-version")
+        if Path(f).is_file():
             pegasus_version = f
 
     if pegasus_version:
@@ -872,7 +872,7 @@ def pegasus_version():
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             shell=True,
-            cwd=os.getcwd(),
+            cwd=Path.cwd(),
         )
         out, err = child.communicate()
         if child.returncode != 0:

--- a/packages/pegasus-python/src/Pegasus/user.py
+++ b/packages/pegasus-python/src/Pegasus/user.py
@@ -6,8 +6,8 @@ module-level lookup functions :func:`get_user_by_uid` and
 :func:`get_user_by_username`.
 """
 
-import os
 import pwd
+from pathlib import Path
 
 
 class NoSuchUser(Exception):
@@ -31,15 +31,15 @@ class User:
 
     def get_pegasus_dir(self):
         """Return the path to the user's ``~/.pegasus`` directory."""
-        return os.path.join(self.homedir, ".pegasus")
+        return str(Path(self.homedir) / ".pegasus")
 
     def get_ensembles_dir(self):
         """Return the path to the user's ``~/.pegasus/ensembles`` directory."""
-        return os.path.join(self.homedir, ".pegasus", "ensembles")
+        return str(Path(self.homedir) / ".pegasus" / "ensembles")
 
     def get_master_db(self):
         """Return the path to the user's Pegasus master SQLite database file."""
-        return os.path.join(self.homedir, ".pegasus", "workflow.db")
+        return str(Path(self.homedir) / ".pegasus" / "workflow.db")
 
     def get_master_db_url(self):
         """Return a SQLAlchemy connection URL for the user's master database."""

--- a/packages/pegasus-python/test/cli/test_pegasus_cwl_converter.py
+++ b/packages/pegasus-python/test/cli/test_pegasus_cwl_converter.py
@@ -1094,7 +1094,7 @@ def test_main(mocker):
 
         assert main(args) == 0
 
-    with open(converted_wf_file_path) as f:
+    with Path(converted_wf_file_path).open() as f:
         result = yaml.load(f)
 
         # removing file info as this is not needed for test

--- a/packages/pegasus-python/test/db/admin/test_dbadmin.py
+++ b/packages/pegasus-python/test/db/admin/test_dbadmin.py
@@ -1,6 +1,6 @@
-import os
 import shutil
 import uuid
+from pathlib import Path
 
 import pytest
 from sqlalchemy import text
@@ -157,7 +157,7 @@ def test_connection_from_properties_file(tmp_path):
     props_filename = str(uuid.uuid4())
     dburi = "sqlite://"
 
-    with open(props_filename, "w") as f:
+    with Path(props_filename).open("w") as f:
         # JDBCRC
         f.write("pegasus.catalog.replica=JDBCRC\n")
         f.write("pegasus.catalog.replica.db.driver=SQLite\n")
@@ -211,7 +211,7 @@ def test_upper_version():
 
 @pytest.mark.parametrize("input", ["test-01.db", "test-02.db"])
 def test_dbs(input, tmp_path):
-    orig_filename = os.path.dirname(os.path.abspath(__file__)) + "/input/" + input
+    orig_filename = Path(__file__).resolve().parent / "input" / input
     filename = str(uuid.uuid4())
     shutil.copyfile(orig_filename, filename)
     dburi = f"sqlite:///{filename}"

--- a/packages/pegasus-python/test/db/test_connection.py
+++ b/packages/pegasus-python/test/db/test_connection.py
@@ -1,8 +1,8 @@
 import errno
-import os
 import re
 import unittest
 import uuid
+from pathlib import Path
 
 from Pegasus.db import connection
 from Pegasus.db.admin.admin_loader import *
@@ -65,16 +65,17 @@ class TestConnection(unittest.TestCase):
 
 def _silentremove(filename):
     try:
-        os.remove(filename)
+        Path(filename).unlink()
     except OSError as e:
         if e.errno != errno.ENOENT:  # errno.ENOENT = no such file or directory
             raise  # re-raise exception if a different error occurred
 
 
 def _remove(filename):
-    for f in os.listdir("."):
+    for path in Path().iterdir():
+        f = str(path)
         if re.search(filename + ".*", f):
-            os.remove(f)
+            path.unlink()
     _silentremove(filename)
 
 

--- a/packages/pegasus-python/test/service/__init__.py
+++ b/packages/pegasus-python/test/service/__init__.py
@@ -9,6 +9,7 @@ import tempfile
 import threading
 import unittest
 from io import StringIO
+from pathlib import Path
 
 from flask import json
 from werkzeug.serving import make_server
@@ -27,7 +28,7 @@ class TestCase(unittest.TestCase):
 
     def tearDown(self):
         # Remove the temp dir
-        if os.path.isdir(self.tmpdir):
+        if Path(self.tmpdir).is_dir():
             shutil.rmtree(self.tmpdir)
 
 
@@ -36,7 +37,7 @@ class DBTestCase(TestCase):
 
     def setUp(self):
         TestCase.setUp(self)
-        self.dbfile = os.path.join(self.tmpdir, "workflow.db")
+        self.dbfile = str(Path(self.tmpdir) / "workflow.db")
         self.dburi = f"sqlite:///{self.dbfile}"
         app.config.update(SQLALCHEMY_DATABASE_URI=self.dburi)
         migrations.create()
@@ -44,7 +45,7 @@ class DBTestCase(TestCase):
     def tearDown(self):
         db.session.remove()
         migrations.drop()
-        os.remove(self.dbfile)
+        Path(self.dbfile).unlink()
         TestCase.tearDown(self)
 
 

--- a/packages/pegasus-python/test/service/ensembles/_test_manager.py
+++ b/packages/pegasus-python/test/service/ensembles/_test_manager.py
@@ -1,6 +1,6 @@
-import os
 import sys
 import time
+from pathlib import Path
 
 from StringIO import StringIO
 
@@ -172,22 +172,22 @@ class ScriptTest(TestCase):
         em.forkscript("true")
 
         cwdfile = "/tmp/forkscript.cwd"
-        if os.path.isfile(cwdfile):
-            os.remove(cwdfile)
+        if Path(cwdfile).is_file():
+            Path(cwdfile).unlink()
         em.forkscript(f"echo $PWD > {cwdfile}", cwd="/")
         time.sleep(1)  # This just gives the script time to finish
-        cwd = open(cwdfile).read().strip()
+        cwd = Path(cwdfile).open().read().strip()
         self.assertEqual(cwd, "/")
-        os.remove(cwdfile)
+        Path(cwdfile).unlink()
 
         pidfile = "/tmp/forkscript.pid"
-        if os.path.isfile(pidfile):
-            os.remove(pidfile)
+        if Path(pidfile).is_file():
+            Path(pidfile).unlink()
         em.forkscript("true", cwd="/tmp", pidfile="/tmp/forkscript.pid")
-        self.assertTrue(os.path.isfile(pidfile))
-        pid = int(open(pidfile).read())
+        self.assertTrue(Path(pidfile).is_file())
+        pid = int(Path(pidfile).open().read())
         self.assertTrue(pid > 0)
-        os.remove(pidfile)
+        Path(pidfile).unlink()
 
         self.assertRaises(
             em.EMException, em.forkscript, "true", cwd="/some/path/not/existing"
@@ -200,12 +200,12 @@ class ScriptTest(TestCase):
         em.runscript("true")
 
         cwdfile = "/tmp/runscript.cwd"
-        if os.path.isfile(cwdfile):
-            os.remove(cwdfile)
+        if Path(cwdfile).is_file():
+            Path(cwdfile).unlink()
         em.runscript(f"echo $PWD > {cwdfile}", cwd="/")
-        cwd = open(cwdfile).read().strip()
+        cwd = Path(cwdfile).open().read().strip()
         self.assertEqual(cwd, "/")
-        os.remove(cwdfile)
+        Path(cwdfile).unlink()
 
         self.assertRaises(
             em.EMException, em.runscript, "true", cwd="/some/path/not/existing"
@@ -396,7 +396,7 @@ class WorkflowTest(UserTestCase):
         self.assertTrue(p.planning_successful(), "Planning should succeed")
 
         submitdir = p.get_submitdir()
-        self.assertTrue(os.path.isdir(submitdir), "Submit dir should exist")
+        self.assertTrue(Path(submitdir).is_dir(), "Submit dir should exist")
 
         wf_uuid = p.get_wf_uuid()
         self.assertTrue(wf_uuid is not None, "wf_uuid should exist")
@@ -444,7 +444,7 @@ class WorkflowTest(UserTestCase):
         self.assertTrue(p.planning_successful())
 
         submitdir = p.get_submitdir()
-        self.assertTrue(os.path.isdir(submitdir))
+        self.assertTrue(Path(submitdir).is_dir())
 
         wf_uuid = p.get_wf_uuid()
         self.assertTrue(wf_uuid is not None)
@@ -536,8 +536,8 @@ class WorkflowTest(UserTestCase):
             </adag>
         """
 
-        subdaxfile = os.path.join(self.tmpdir, "subdax.xml")
-        f = open(subdaxfile, "w")
+        subdaxfile = str(Path(self.tmpdir) / "subdax.xml")
+        f = Path(subdaxfile).open("w")
         f.write(subdax)
         f.close()
 

--- a/packages/pegasus-python/test/service/ensembles/_test_views.py
+++ b/packages/pegasus-python/test/service/ensembles/_test_views.py
@@ -1,4 +1,5 @@
 import time
+from pathlib import Path
 
 from Pegasus.service import api, db, ensembles
 from Pegasus.service.ensembles import *
@@ -228,18 +229,18 @@ class TestEnsembleAPI(APITestCase):
         self.assertTrue("location" in r.headers, "Should have location header")
 
         # Make sure all the files were created
-        wfdir = os.path.join(
-            self.tmpdir, "userdata/scott/ensembles/myensemble/workflows/mywf"
+        wfdir = str(
+            Path(self.tmpdir) / "userdata/scott/ensembles/myensemble/workflows/mywf"
         )
-        self.assertTrue(os.path.isfile(os.path.join(wfdir, "sites.xml")))
-        self.assertTrue(os.path.isfile(os.path.join(wfdir, "dax.xml")))
-        self.assertTrue(os.path.isfile(os.path.join(wfdir, "rc.txt")))
-        self.assertTrue(os.path.isfile(os.path.join(wfdir, "tc.txt")))
-        self.assertTrue(os.path.isfile(os.path.join(wfdir, "pegasus.properties")))
-        planfile = os.path.join(wfdir, "plan.sh")
-        self.assertTrue(os.path.isfile(planfile))
+        self.assertTrue(Path(str(Path(wfdir) / "sites.xml")).is_file())
+        self.assertTrue(Path(str(Path(wfdir) / "dax.xml")).is_file())
+        self.assertTrue(Path(str(Path(wfdir) / "rc.txt")).is_file())
+        self.assertTrue(Path(str(Path(wfdir) / "tc.txt")).is_file())
+        self.assertTrue(Path(str(Path(wfdir) / "pegasus.properties")).is_file())
+        planfile = str(Path(wfdir) / "plan.sh")
+        self.assertTrue(Path(planfile).is_file())
 
-        planscript = open(planfile).read()
+        planscript = Path(planfile).open().read()
         self.assertTrue("--nocleanup" in planscript)
         self.assertTrue("--force" in planscript)
         self.assertTrue("--cluster horizontal,vertical" in planscript)
@@ -340,8 +341,8 @@ class LargeDAXTest(ClientTestCase):
         db.session.commit()
 
         # Create a 256MB file and submit it as the DAX
-        daxfile = os.path.join(self.tmpdir, "large.dax")
-        dax = open(daxfile, "w")
+        daxfile = str(Path(self.tmpdir) / "large.dax")
+        dax = Path(daxfile).open("w")
         for i in range(0, 256 * 1024):
             dax.write("x" * 1024)
         dax.close()

--- a/packages/pegasus-python/test/service/ensembles/test_bundle.py
+++ b/packages/pegasus-python/test/service/ensembles/test_bundle.py
@@ -1,8 +1,8 @@
-import os
 import shutil
 import tempfile
 import unittest
 import zipfile
+from pathlib import Path
 
 from Pegasus.service.ensembles.bundle import *
 
@@ -14,7 +14,7 @@ class TestBundle(unittest.TestCase):
 
     def tearDown(self):
         self.zipfile.close()
-        os.remove(self.filename)
+        Path(self.filename).unlink()
 
     def test_invalid(self):
         self.assertRaises(BundleException, Bundle, "/nosuchfile")
@@ -103,10 +103,10 @@ class TestBundle(unittest.TestCase):
         self.zipfile.close()
         bundle = Bundle(self.filename)
         dirname = tempfile.mkdtemp()
-        filename = os.path.join(dirname, PROPERTIES_NAME)
+        filename = str(Path(dirname) / PROPERTIES_NAME)
         try:
             bundle.unpack(dirname)
-            self.assertTrue(os.path.isfile(filename))
-            self.assertEqual(open(filename).read(), "hello=world")
+            self.assertTrue(Path(filename).is_file())
+            self.assertEqual(Path(filename).open().read(), "hello=world")
         finally:
             shutil.rmtree(dirname)

--- a/packages/pegasus-python/test/service/monitoring/test_views.py
+++ b/packages/pegasus-python/test/service/monitoring/test_views.py
@@ -1,5 +1,5 @@
 import getpass
-import os
+from pathlib import Path
 
 import pytest
 from flask import g
@@ -15,9 +15,11 @@ class NoAuthFlaskTestCase:
 
     @staticmethod
     def pre_callable():
-        directory = os.path.dirname(__file__)
-        db = os.path.join(
-            directory, "../../resources/monitoring-db/", "monitoring-rest-api-master.db"
+        directory = Path(__file__).parent
+        db = str(
+            Path(directory)
+            / "../../resources/monitoring-db/"
+            / "monitoring-rest-api-master.db"
         )
         g.master_db_url = f"sqlite:///{db}"
         g.stampede_db_url = f"sqlite:///{db}"

--- a/packages/pegasus-python/test/test_exitcode.py
+++ b/packages/pegasus-python/test/test_exitcode.py
@@ -1,12 +1,12 @@
 """Test Pegasus exitcode."""
 
-import os
 import unittest
+from pathlib import Path
 
 from Pegasus import exitcode
 from Pegasus.exitcode import JobFailed
 
-dirname = os.path.abspath(os.path.dirname(__file__))
+dirname = Path(Path(__file__).parent).resolve()
 
 
 class ExitcodeTestCase(unittest.TestCase):
@@ -62,7 +62,7 @@ class ExitcodeTestCase(unittest.TestCase):
 
     def test_exitcode(self):
         def ec(filename, **args):
-            path = os.path.join(dirname, "exitcode", filename)
+            path = str(Path(dirname) / "exitcode" / filename)
             exitcode.exitcode(path, rename=False, **args)
 
         # new yaml format
@@ -165,13 +165,13 @@ class ExitcodeTestCase(unittest.TestCase):
         ec("empty.out", dagman_job_status=0, check_invocations=False)
 
     def test_rename_noerrfile(self):
-        inf = os.path.join(dirname, "exitcode", "ok.out")
-        outf = os.path.join(dirname, "exitcode", "ok.out.000")
+        inf = str(Path(dirname) / "exitcode" / "ok.out")
+        outf = str(Path(dirname) / "exitcode" / "ok.out.000")
         exitcode.exitcode(inf, rename=True)
-        exists = os.path.isfile(outf)
+        exists = Path(outf).is_file()
         self.assertTrue(exists)
         if exists:
-            os.rename(outf, inf)
+            Path(outf).rename(inf)
 
 
 if __name__ == "__main__":

--- a/packages/pegasus-python/test/test_utils.py
+++ b/packages/pegasus-python/test/test_utils.py
@@ -1,6 +1,7 @@
 import os
 import time
 import unittest
+from pathlib import Path
 
 from Pegasus.tools import utils
 
@@ -230,8 +231,8 @@ class TestEpochDate(unittest.TestCase):
 
 class TestFindExec(unittest.TestCase):
     def setUp(self):
-        self.test_dir = os.path.abspath(os.path.dirname(__file__))
-        self.cwd = os.getcwd()
+        self.test_dir = Path(Path(__file__).parent).resolve()
+        self.cwd = Path.cwd()
         os.chdir(self.test_dir)
 
     def tearDown(self):

--- a/packages/pegasus-worker/setup.py
+++ b/packages/pegasus-worker/setup.py
@@ -7,11 +7,12 @@ _extended_summary_
 """
 
 import os
+from pathlib import Path
 
 from setuptools import setup
 
-src_dir = os.path.dirname(__file__)
-home_dir = os.path.abspath(os.path.join(src_dir, "../.."))
+src_dir = Path(__file__).parent
+home_dir = str((src_dir / "../..").absolute())
 
 install_requires = [
     "six>=1.9.0",
@@ -24,7 +25,7 @@ install_requires = [
 # Utility function to read the README file.
 #
 def read(fname):
-    return open(os.path.join(src_dir, fname)).read()
+    return open(src_dir / fname).read()
 
 
 # TODO: Someday remove this method and replace with setuptools.find_namespace_packages
@@ -36,7 +37,7 @@ def find_namespace_packages(where):
             if pkg == where or pkg.endswith(".egg-info") or pkg == "__pycache__":
                 continue
 
-            pkgs.append(os.path.join(root, pkg).replace("/", "."))
+            pkgs.append(str(Path(root) / pkg).replace("/", "."))
     return pkgs
 
 

--- a/packages/pegasus-worker/src/Pegasus/cli/pegasus-globus-online-init.py
+++ b/packages/pegasus-worker/src/Pegasus/cli/pegasus-globus-online-init.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-import os
 from argparse import ArgumentParser
+from pathlib import Path
 
 import globus_sdk
 from globus_sdk.scopes import (
@@ -16,7 +16,7 @@ except Exception:
     from ConfigParser import ConfigParser
 
 client_id = "d7382f5a-4ea3-4b69-b094-99c392fc820d"
-config_file = os.path.expanduser("~/.pegasus/globus.conf")
+config_file = Path("~/.pegasus/globus.conf").expanduser()
 
 parser = ArgumentParser(
     description="Initialize Globus OAuth Tokens - SDK Version {}".format(

--- a/packages/pegasus-worker/src/Pegasus/cli/pegasus-globus-online.py
+++ b/packages/pegasus-worker/src/Pegasus/cli/pegasus-globus-online.py
@@ -29,13 +29,14 @@ import re
 import signal
 import sys
 from datetime import datetime, timedelta
+from pathlib import Path
 
 import globus_sdk
 
 # --- global variables ----------------------------------------------------------------
 
-prog_dir = os.path.realpath(os.path.join(os.path.dirname(sys.argv[0])))
-prog_base = os.path.split(sys.argv[0])[1]  # Name of this program
+prog_dir = str(Path(sys.argv[0]).parent.resolve())
+prog_base = Path(sys.argv[0]).name  # Name of this program
 
 logger = logging.getLogger("Pegasus")
 
@@ -180,7 +181,10 @@ def mkdir(request):
         found = False
         while (not found) and base_path != "/":
             found = True
-            base_path, dir_name = os.path.split(base_path)
+            base_path, dir_name = (
+                str(Path(base_path).parent),
+                Path(base_path).name,
+            )
             if dir_name not in ["", "/"]:
                 child_dirs.append(dir_name)
             try:

--- a/packages/pegasus-worker/src/Pegasus/cli/pegasus-integrity.py
+++ b/packages/pegasus-worker/src/Pegasus/cli/pegasus-integrity.py
@@ -15,6 +15,7 @@ import pprint
 import sys
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 from shlex import quote
 
 # PEGASUS_PYTHONPATH is set by the pegasus-python-wrapper script
@@ -91,8 +92,8 @@ class Singleton(type):
 
 # --- global variables ----------------------------------------------------------------
 
-prog_dir = os.path.realpath(os.path.join(os.path.dirname(sys.argv[0])))
-prog_base = os.path.split(sys.argv[0])[1]  # Name of this program
+prog_dir = str(Path(sys.argv[0]).parent.resolve())
+prog_base = Path(sys.argv[0]).name  # Name of this program
 
 logger = logging.getLogger("PegasusIntegrity")
 
@@ -193,7 +194,7 @@ def read_meta_data(f):
     # don't try to load empty files
     size = 0
     try:
-        size = os.path.getsize(f)
+        size = Path(f).stat().st_size
     except Exception as err:
         logger.critical("Unable to open metadata file: " + str(err))
     if size <= 2:
@@ -251,9 +252,9 @@ def generate_sha256(fname):
         logger.error("openssl or sha256sum not found!")
         return None
 
-    # GH-2117 we cannot pass the quoted name. os.path.exists() handles
+    # GH-2117 we cannot pass the quoted name. Path.exists() handles
     # whitespaces correctly without requiring any quoting
-    if not os.path.exists(fname):
+    if not Path(fname).exists():
         logger.error("File " + fname + " does not exist")
         return None
 

--- a/packages/pegasus-worker/src/Pegasus/s3.py
+++ b/packages/pegasus-worker/src/Pegasus/s3.py
@@ -29,6 +29,7 @@ import stat
 import sys
 from argparse import ArgumentParser
 from configparser import ConfigParser
+from pathlib import Path, PurePosixPath
 from urllib.parse import urlsplit
 
 from Pegasus.tools.worker_utils import logger
@@ -267,16 +268,18 @@ def get_path_for_key(bucket, searchkey, key, output):
 
     # If output ends with a /, then we need to add a name onto it
     if output.endswith("/"):
-        name = bucket if searchkey == "" else os.path.basename(searchkey)
-        output = os.path.join(output, name)
+        name = bucket if searchkey == "" else Path(searchkey).name
+        output = str(Path(output) / name)
 
     if searchkey == key:
         # If they are the same, then return the new output path
         return output
     else:
         # Otherwise we need to compute the relative path and add it
-        relpath = os.path.relpath(key, searchkey)
-        return os.path.join(output, relpath)
+        relpath = (
+            key if searchkey == "" else str(PurePosixPath(key).relative_to(searchkey))
+        )
+        return str(Path(output) / relpath)
 
 
 DEFAULT_CREDENTIAL_PATH = "~/.pegasus/credentials.conf"
@@ -308,14 +311,14 @@ def get_config(options):
         cfg = S3CFG
     else:
         # New default
-        new_default = os.path.expanduser(DEFAULT_CREDENTIAL_PATH)
-        if os.path.isfile(new_default):
+        new_default = str(Path(DEFAULT_CREDENTIAL_PATH).expanduser())
+        if Path(new_default).is_file():
             cfg = new_default
         else:
             # If the new default doesn't exist, try the old default
-            cfg = os.path.expanduser(OLD_DEFAULT_CREDENTIAL_PATH)
+            cfg = str(Path(OLD_DEFAULT_CREDENTIAL_PATH).expanduser())
 
-    if not os.path.isfile(cfg):
+    if not Path(cfg).is_file():
         raise Exception("Config file not found")
 
     log.info("Found config file: %s" % cfg)
@@ -927,12 +930,12 @@ def get_key_for_path(path, infile, outkey):
         raise Exception(f"file '{infile}' is not relative to '{path}'")
 
     if outkey.endswith("/"):
-        name = os.path.basename(path)
+        name = Path(path).name
         outkey = outkey + name
 
-    relpath = os.path.relpath(infile, path)
+    relpath = str(PurePosixPath(infile).relative_to(path))
     if relpath != ".":
-        return os.path.join(outkey, relpath)
+        return str(Path(outkey) / relpath)
     else:
         return outkey
 
@@ -946,10 +949,10 @@ def put(args):
     path = fix_file(args.file)
     url = args.url
 
-    if not os.path.exists(path):
+    if not Path(path).exists():
         raise Exception(f"No such file or directory: {path}")
 
-    if os.path.isdir(path):
+    if Path(path).is_dir():
         raise Exception("FILE: %s is a directory. FILE must be a file." % path)
 
     log.info(f"Attempting to upload {path}")
@@ -959,7 +962,7 @@ def put(args):
     if uri.bucket is None:
         raise Exception("URL for put must have a bucket: %s" % url)
     if uri.key is None:
-        uri.key = os.path.basename(path)
+        uri.key = Path(path).name
 
     config = get_config(args)
 
@@ -1037,7 +1040,7 @@ def get(args):
     if args.file:
         output = fix_file(args.file)
     else:
-        output = os.path.basename(uri.key.rstrip("/"))
+        output = Path(uri.key.rstrip("/")).name
 
     log.info("Downloading %s" % uri)
 

--- a/packages/pegasus-worker/src/Pegasus/tools/worker_utils.py
+++ b/packages/pegasus-worker/src/Pegasus/tools/worker_utils.py
@@ -24,6 +24,7 @@ import sys
 import tempfile
 import threading
 import time
+from pathlib import Path
 
 # Module variables
 logger = logging.getLogger("Pegasus")
@@ -276,7 +277,7 @@ class Tools:
                 full_path = None
                 for entry in path_entries:
                     full_path = entry + "/" + executable
-                    if os.path.isfile(full_path) and os.access(full_path, os.X_OK):
+                    if Path(full_path).is_file() and os.access(full_path, os.X_OK):
                         break
                     full_path = None
 

--- a/packages/pegasus-worker/src/Pegasus/transfer.py
+++ b/packages/pegasus-worker/src/Pegasus/transfer.py
@@ -69,6 +69,7 @@ if "KICKSTART_MON_ENDPOINT_URL" in os.environ:
         from urllib import request as urllib2
     except ImportError:
         import urllib2
+from pathlib import Path
 
 __author__ = "Mats Rynge <rynge@isi.edu>"
 
@@ -174,7 +175,7 @@ class PegasusURL:
         return f"{self.proto}://{self.host}{urllib.quote(self.path)}"
 
     def get_url_dirname(self):
-        dn = os.path.dirname(self.path)
+        dn = str(Path(self.path).parent)
         return f"{self.proto}://{self.host}{dn}"
 
 
@@ -615,24 +616,24 @@ class TransferHandlerBase:
                 return False
             if a.get_dst_host() != b.get_dst_host():
                 return False
-            if os.path.dirname(a.get_src_path()) != os.path.dirname(b.get_src_path()):
+            if str(Path(a.get_src_path()).parent) != str(Path(b.get_src_path()).parent):
                 return False
-            if os.path.dirname(a.get_dst_path()) != os.path.dirname(b.get_dst_path()):
+            if str(Path(a.get_dst_path()).parent) != str(Path(b.get_dst_path()).parent):
                 return False
             if a.generate_checksum != b.generate_checksum:
                 return False
 
             # also check that we are not renaming the files
-            if os.path.basename(a.get_src_path()) != os.path.basename(a.get_dst_path()):
+            if Path(a.get_src_path()).name != Path(a.get_dst_path()).name:
                 return False
-            if os.path.basename(b.get_src_path()) != os.path.basename(b.get_dst_path()):
+            if Path(b.get_src_path()).name != Path(b.get_dst_path()).name:
                 return False
 
             return True
         elif isinstance(a, Remove) and isinstance(b, Remove):
             if a.get_host() != b.get_host():
                 return False
-            if os.path.dirname(a.get_path()) != os.path.dirname(b.get_path()):
+            if str(Path(a.get_path()).parent) != str(Path(b.get_path()).parent):
                 return False
             return True
         return False
@@ -675,7 +676,7 @@ class TransferHandlerBase:
         systems we have to deal with, such as CVMFS, checking POSIX permissions
         is not enough. Here we try to open() the file to make sure it works.
         """
-        if not os.path.exists(path):
+        if not Path(path).exists():
             return False
 
         # for non-zero sized files, try to read a little bit at the beginning
@@ -730,7 +731,7 @@ class FileHandler(TransferHandlerBase):
         failed_l = []
         for t in transfers:
             t_start = time.time()
-            prepare_local_dir(os.path.dirname(t.get_dst_path()))
+            prepare_local_dir(str(Path(t.get_dst_path()).parent))
 
             # src has to exist and be readable
             if not verify_local_file(t.get_src_path()):
@@ -740,7 +741,7 @@ class FileHandler(TransferHandlerBase):
 
             self._pre_transfer_attempt(t)
 
-            if os.path.exists(t.get_src_path()) and os.path.exists(t.get_dst_path()):
+            if Path(t.get_src_path()).exists() and Path(t.get_dst_path()).exists():
                 # make sure src and target are not the same file - have to
                 # compare at the inode level as paths can differ
                 src_inode = os.stat(t.get_src_path())[stat.ST_INO]
@@ -1074,7 +1075,7 @@ class GridFtpHandler(TransferHandlerBase):
         # for transfer to file://, run a normal mkdir command instead of
         # having g-u-c use -create-dest
         if transfers[0].get_dst_proto() == "file":
-            prepare_local_dir(os.path.dirname(transfers[0].get_dst_path()))
+            prepare_local_dir(str(Path(transfers[0].get_dst_path()).parent))
             # override the create_dest flag as the directory now exists
             create_dest = False
 
@@ -1228,9 +1229,9 @@ class GridFtpHandler(TransferHandlerBase):
             return False
         if a.get_dst_host() != b.get_dst_host():
             return False
-        if os.path.dirname(a.get_src_path()) != os.path.dirname(b.get_src_path()):
+        if str(Path(a.get_src_path()).parent) != str(Path(b.get_src_path()).parent):
             return False
-        if os.path.dirname(a.get_dst_path()) != os.path.dirname(b.get_dst_path()):
+        if str(Path(a.get_dst_path()).parent) != str(Path(b.get_dst_path()).parent):
             return False
         return True
 
@@ -1293,7 +1294,7 @@ class HttpHandler(TransferHandlerBase):
 
             self._pre_transfer_attempt(t)
 
-            prepare_local_dir(os.path.dirname(t.get_dst_path()))
+            prepare_local_dir(str(Path(t.get_dst_path()).parent))
 
             # try wget first, then curl
             if tools.full_path("wget") is not None:
@@ -1392,13 +1393,13 @@ class HPSSHandler(TransferHandlerBase):
         user_defined_cred = (
             os.environ["HPSS_CREDENTIAL"] if "HPSS_CREDENTIAL" in os.environ else None
         )
-        default_cred = os.path.join(os.environ["HOME"], ".netrc")
+        default_cred = str(Path(os.environ["HOME"]) / ".netrc")
 
         if user_defined_cred:
             # user defined credential exists and is a file
             check_cred_fs_permissions(user_defined_cred)
 
-            if os.path.exists(default_cred):
+            if Path(default_cred).exists():
                 # first check if they are not the same file
                 src_inode = os.stat(user_defined_cred)[stat.ST_INO]
                 dst_inode = os.stat(default_cred)[stat.ST_INO]
@@ -1426,7 +1427,7 @@ class HPSSHandler(TransferHandlerBase):
         Checks to make sure a given credential exists and is protected
         by the file system permissions.
         """
-        if not os.path.exists(path):
+        if not Path(path).exists():
             raise Exception("HPSS Credential file %s does not exist" % (path))
         if (os.stat(path).st_mode & 0o777) != 0o600:
             logger.warning("%s found to have weak permissions. chmod to 0600." % (path))
@@ -1559,7 +1560,7 @@ class HPSSHandler(TransferHandlerBase):
         # todo enable checksum verification -Hverify=crc
 
         try:
-            prepare_local_dir(os.path.dirname(destination_dir))
+            prepare_local_dir(str(Path(destination_dir).parent))
             logger.debug("Executing command " + cmd)
             tc = utils.TimedCommand(cmd, cwd=destination_dir)
             tc.run()
@@ -1575,10 +1576,10 @@ class HPSSHandler(TransferHandlerBase):
                 # check if file has to be moved after untarring
                 if t.lfn in files_to_move:
                     # mv src_file to t.lfn
-                    src_file = os.path.join(destination_dir, files_to_move[t.lfn])
-                    dst_file = os.path.join(destination_dir, t.lfn)
+                    src_file = str(Path(destination_dir) / files_to_move[t.lfn])
+                    dst_file = str(Path(destination_dir) / t.lfn)
                     # account for deep LFN
-                    prepare_local_dir(os.path.dirname(dst_file))
+                    prepare_local_dir(str(Path(dst_file).parent))
                     try:
                         os.rename(src_file, dst_file)
                     except Exception as err:
@@ -1632,15 +1633,15 @@ class HPSSHandler(TransferHandlerBase):
 
         # tar file should be the first component of the path
         tar = url
-        parent = os.path.dirname(tar)
+        parent = str(Path(tar).parent)
         while parent:
             if parent == "/":
                 break
             tar = parent
-            parent = os.path.dirname(tar)
+            parent = str(Path(tar).parent)
 
         # remove leading / if any
-        tar = os.path.basename(tar)
+        tar = Path(tar).name
 
         if not tar.endswith(".tar"):
             logger.error("Unable to determine HPSS tar from URL %s", url)
@@ -1801,7 +1802,7 @@ class IRodsHandler(TransferHandlerBase):
 
             if t.get_dst_proto() == "file":
                 # irods->file
-                prepare_local_dir(os.path.dirname(t.get_dst_path()))
+                prepare_local_dir(str(Path(t.get_dst_path()).parent))
                 cmd = "iget -v -f -T -K -N 4"
                 if len(t.get_src_host()) > 0 and t.attempts <= 1:
                     cmd += " -R " + t.get_src_host()
@@ -1816,7 +1817,7 @@ class IRodsHandler(TransferHandlerBase):
                     failed_l.append(t)
                     self._post_transfer_attempt(t, False, t_start)
                     continue
-                cmd = "imkdir -p '" + os.path.dirname(t.get_dst_path()) + "'"
+                cmd = "imkdir -p '" + str(Path(t.get_dst_path()).parent) + "'"
                 try:
                     tc = utils.TimedCommand(
                         cmd, env_overrides=env, timeout_secs=10 * 60
@@ -1943,7 +1944,7 @@ class IRodsHandler(TransferHandlerBase):
             if ticket is not None:
                 env["IRODS_TICKET"] = ticket
 
-            if os.path.exists(env["IRODS_AUTHENTICATION_FILE"]):
+            if Path(env["IRODS_AUTHENTICATION_FILE"]).exists():
                 # no need to log in again
                 return env
 
@@ -2059,7 +2060,7 @@ class S3Handler(TransferHandlerBase):
             elif t.get_dst_proto() == "file":
                 # this is a 'get'
                 env = self._s3_cred_env(t.get_src_site_label())
-                prepare_local_dir(os.path.dirname(t.get_dst_path()))
+                prepare_local_dir(str(Path(t.get_dst_path()).parent))
                 cmd = tools.full_path("pegasus-s3") + " get '{}' '{}'".format(
                     t.src_url(),
                     t.get_dst_path(),
@@ -2198,7 +2199,7 @@ class GlobusOnlineHandler(TransferHandlerBase):
             logger.error("Unable to locate pegasus-globus-online in the $PATH")
             return [[], mkdir_l]
 
-        if not os.path.isfile(os.path.expanduser("~/.pegasus/globus.conf")):
+        if not Path(str(Path("~/.pegasus/globus.conf").expanduser())).is_file():
             logger.error("Unable to locate globus config file ~/.pegasus/globus.conf")
             return [[], mkdir_l]
 
@@ -2251,7 +2252,7 @@ class GlobusOnlineHandler(TransferHandlerBase):
             logger.error("Unable to locate pegasus-globus-online in the $PATH")
             return [[], transfers_l]
 
-        if not os.path.isfile(os.path.expanduser("~/.pegasus/globus.conf")):
+        if not Path(str(Path("~/.pegasus/globus.conf").expanduser())).is_file():
             logger.error("Unable to locate globus config file ~/.pegasus/globus.conf")
             return [[], transfers_l]
 
@@ -2314,7 +2315,7 @@ class GlobusOnlineHandler(TransferHandlerBase):
             logger.error("Unable to locate pegasus-globus-online in the $PATH")
             return [[], removes_l]
 
-        if not os.path.isfile(os.path.expanduser("~/.pegasus/globus.conf")):
+        if not Path(str(Path("~/.pegasus/globus.conf").expanduser())).is_file():
             logger.error("Unable to locate globus config file ~/.pegasus/globus.conf")
             return [[], removes_l]
 
@@ -2370,7 +2371,7 @@ class GlobusOnlineHandler(TransferHandlerBase):
         logger.info("Parsing globus config file for OAuth credentials")
 
         config = configparser.ConfigParser()
-        config.read(os.path.expanduser("~/.pegasus/globus.conf"))
+        config.read(str(Path("~/.pegasus/globus.conf").expanduser()))
 
         cred_details = {
             "client_id": None,
@@ -2497,7 +2498,7 @@ class GSHandler(TransferHandlerBase):
                 cmd = f"gsutil -q cp '{t.src_url()}' '{t.dst_url()}'"
             elif t.get_dst_proto() == "file":
                 # this is a 'get'
-                prepare_local_dir(os.path.dirname(t.get_dst_path()))
+                prepare_local_dir(str(Path(t.get_dst_path()).parent))
                 cmd = f"gsutil -q cp '{t.src_url()}' '{t.get_dst_path()}'"
             else:
                 # this is a 'put'
@@ -2688,7 +2689,7 @@ class GFALHandler(TransferHandlerBase):
             t_start = time.time()
 
             if t.get_dst_proto() == "file":
-                prepare_local_dir(os.path.dirname(t.get_dst_path()))
+                prepare_local_dir(str(Path(t.get_dst_path()).parent))
 
             if t.get_src_proto() == "file":
                 # src has to exist and be readable
@@ -2754,7 +2755,7 @@ class GFALHandler(TransferHandlerBase):
     def _gfal_validate_cred(self, env_overrides):
         fname = env_overrides["X509_USER_PROXY"]
 
-        if not (os.path.exists(fname)):
+        if not (Path(fname).exists()):
             raise RuntimeError(
                 "X509 proxy file "
                 + fname
@@ -2871,7 +2872,7 @@ class ScpHandler(TransferHandlerBase):
                         cmd += " -i " + os.environ["SSH_PRIVATE_KEY"]
 
                     cmd += " -P " + self._extract_port(t_base.get_src_host())
-                    prepare_local_dir(os.path.dirname(t_base.get_dst_path()))
+                    prepare_local_dir(str(Path(t_base.get_dst_path()).parent))
                     # scp wants escaped remote paths, even with quotes
                     for t in t_group:
                         src_path = re.sub(" ", "\\ ", t.get_src_path())
@@ -2883,7 +2884,7 @@ class ScpHandler(TransferHandlerBase):
                             + "'"
                         )
                     if len(t_group) > 1:
-                        cmd += " '" + os.path.dirname(t_base.get_dst_path()) + "/'"
+                        cmd += " '" + str(Path(t_base.get_dst_path()).parent) + "/'"
                     else:
                         cmd += " '" + t_base.get_dst_path() + "'"
                 else:
@@ -2912,13 +2913,13 @@ class ScpHandler(TransferHandlerBase):
                         "scp://"
                         + self._extract_hostname(t_base.get_dst_host())
                         + ":"
-                        + os.path.dirname(t_base.get_dst_path())
+                        + str(Path(t_base.get_dst_path()).parent)
                     )
                     if not mkdir_key in remote_dirs_created:
                         self._prepare_scp_dir(
                             t_base.get_dst_site_label(),
                             t_base.get_dst_host(),
-                            os.path.dirname(t_base.get_dst_path()),
+                            str(Path(t_base.get_dst_path()).parent),
                         )
                         remote_dirs_created[mkdir_key] = True
 
@@ -2934,7 +2935,7 @@ class ScpHandler(TransferHandlerBase):
                             " '"
                             + self._extract_hostname(t_base.get_dst_host())
                             + ":"
-                            + os.path.dirname(dst_path)
+                            + str(Path(dst_path).parent)
                             + "/'"
                         )
                     else:
@@ -3144,7 +3145,7 @@ class GSIScpHandler(TransferHandlerBase):
                 if t_base.get_dst_proto() == "file":
                     # scp -> file
                     cmd += " -P " + self._extract_port(t_base.get_src_host())
-                    prepare_local_dir(os.path.dirname(t_base.get_dst_path()))
+                    prepare_local_dir(str(Path(t_base.get_dst_path()).parent))
                     # scp wants escaped remote paths, even with quotes
                     for t in t_group:
                         src_path = re.sub(" ", "\\ ", t.get_src_path())
@@ -3156,7 +3157,7 @@ class GSIScpHandler(TransferHandlerBase):
                             + "'"
                         )
                     if len(t_group) > 1:
-                        cmd += " '" + os.path.dirname(t_base.get_dst_path()) + "/'"
+                        cmd += " '" + str(Path(t_base.get_dst_path()).parent) + "/'"
                     else:
                         cmd += " '" + t_base.get_dst_path() + "'"
                 else:
@@ -3172,13 +3173,13 @@ class GSIScpHandler(TransferHandlerBase):
                         "scp://"
                         + self._extract_hostname(t_base.get_dst_host())
                         + ":"
-                        + os.path.dirname(t_base.get_dst_path())
+                        + str(Path(t_base.get_dst_path()).parent)
                     )
                     if not mkdir_key in remote_dirs_created:
                         self._prepare_scp_dir(
                             t_base.get_dst_site_label(),
                             t_base.get_dst_host(),
-                            os.path.dirname(t_base.get_dst_path()),
+                            str(Path(t_base.get_dst_path()).parent),
                         )
                         remote_dirs_created[mkdir_key] = True
 
@@ -3194,7 +3195,7 @@ class GSIScpHandler(TransferHandlerBase):
                             " '"
                             + self._extract_hostname(t_base.get_dst_host())
                             + ":"
-                            + os.path.dirname(dst_path)
+                            + str(Path(dst_path).parent)
                             + "/'"
                         )
                     else:
@@ -3438,7 +3439,7 @@ class OSDFHandler(TransferHandlerBase):
             else:
                 # read
 
-                local_dir = os.path.dirname(t.get_dst_path())
+                local_dir = str(Path(t.get_dst_path()).parent)
                 prepare_local_dir(local_dir)
                 cmd = f"{base_cmd} '{t.src_url()}' '{t.get_dst_path()}'"
 
@@ -3515,10 +3516,10 @@ class SymlinkHandler(TransferHandlerBase):
             self._pre_transfer_attempt(t)
             t_start = time.time()
 
-            prepare_local_dir(os.path.dirname(t.get_dst_path()))
+            prepare_local_dir(str(Path(t.get_dst_path()).parent))
 
             # we do not allow dangling symlinks
-            if t.verify_symlink_source and not os.path.exists(t.get_src_path()):
+            if t.verify_symlink_source and not Path(t.get_src_path()).exists():
                 logger.warning(
                     "Symlink source (%s) does not exist" % (t.get_src_path())
                 )
@@ -3526,7 +3527,7 @@ class SymlinkHandler(TransferHandlerBase):
                 failed_l.append(t)
                 continue
 
-            if os.path.exists(t.get_src_path()) and os.path.exists(t.get_dst_path()):
+            if Path(t.get_src_path()).exists() and Path(t.get_dst_path()).exists():
                 # make sure src and target are not the same file - have to
                 # compare at the inode level as paths can differ
                 src_inode = os.stat(t.get_src_path())[stat.ST_INO]
@@ -3590,10 +3591,10 @@ class MovetoHandler(TransferHandlerBase):
             t_start = time.time()
 
             print(t.get_dst_path())
-            prepare_local_dir(os.path.dirname(t.get_dst_path()))
+            prepare_local_dir(str(Path(t.get_dst_path()).parent))
 
             # we do not allow dangling symlinks
-            if not os.path.exists(t.get_src_path()):
+            if not Path(t.get_src_path()).exists():
                 logger.warning("Moveto source (%s) does not exist" % (t.get_src_path()))
                 self._post_transfer_attempt(t, False, t_start)
                 failed_l.append(t)
@@ -3642,7 +3643,7 @@ class DockerHandler(TransferHandlerBase):
             src_path = t.src_url()
             src_path = re.sub("^docker:/+", "", src_path)
 
-            prepare_local_dir(os.path.dirname(t.get_dst_path()))
+            prepare_local_dir(str(Path(t.get_dst_path()).parent))
             cmd = "{} pull '{}' && {} save -o '{}' '{}'".format(
                 tools.full_path("docker"),
                 src_path,
@@ -3706,7 +3707,7 @@ class SingularityHandler(TransferHandlerBase):
 
             target_name = hashlib.sha224(t.get_dst_path().encode("utf-8")).hexdigest()
 
-            prepare_local_dir(os.path.dirname(t.get_dst_path()))
+            prepare_local_dir(str(Path(t.get_dst_path()).parent))
 
             cmd = "{} pull --allow-unauthenticated '{}' '{}' && mv {}* '{}'".format(
                 singularity_exec,
@@ -3784,7 +3785,7 @@ class WebdavHandler(TransferHandlerBase):
 
             if t.get_dst_proto() == "file":
                 # webdav -> file
-                prepare_local_dir(os.path.dirname(t.get_dst_path()))
+                prepare_local_dir(str(Path(t.get_dst_path()).parent))
                 url = re.sub("^webdav", "http", t.src_url())
                 cmd = tools.full_path("curl")
                 if not logger.isEnabledFor(logging.DEBUG):
@@ -3809,7 +3810,7 @@ class WebdavHandler(TransferHandlerBase):
                 url = re.sub("^webdav", "http", t.dst_url())
 
                 # might have to create dir first
-                self._create_dir(os.path.dirname(url), username, password)
+                self._create_dir(str(Path(url).parent), username, password)
 
                 cmd = tools.full_path("curl")
                 if not logger.isEnabledFor(logging.DEBUG):
@@ -3847,7 +3848,7 @@ class WebdavHandler(TransferHandlerBase):
                 continue
 
             # also make sure the file was actually downloaded
-            if t.get_dst_proto() == "file" and not os.path.exists(t.get_dst_path()):
+            if t.get_dst_proto() == "file" and not Path(t.get_dst_path()).exists():
                 logger.error(
                     "Expected local file is missing - marking transfer as failed"
                 )
@@ -3855,7 +3856,10 @@ class WebdavHandler(TransferHandlerBase):
                 continue
 
             # also make sure the file was actually downloaded
-            if t.get_dst_proto() == "file" and os.path.getsize(t.get_dst_path()) == 0:
+            if (
+                t.get_dst_proto() == "file"
+                and Path(t.get_dst_path()).stat().st_size == 0
+            ):
                 logger.error("Downloaded file is 0 bytes - marking transfer as failed")
                 failed_l.append(t)
                 continue
@@ -3968,7 +3972,7 @@ class WebdavHandler(TransferHandlerBase):
         return True
 
     def _split_path(self, path):
-        head, tail = os.path.split(path)
+        head, tail = (str(Path(path).parent), Path(path).name)
         return (
             self._split_path(head) + [tail] if head and head != path else [head or tail]
         )
@@ -4677,8 +4681,8 @@ class Alarm(Exception):
 
 # --- global variables ----------------------------------------------------------------
 
-prog_dir = os.path.realpath(os.path.join(os.path.dirname(sys.argv[0])))
-prog_base = os.path.split(sys.argv[0])[1]  # Name of this program
+prog_dir = str(Path(sys.argv[0]).parent.resolve())
+prog_base = Path(sys.argv[0]).name  # Name of this program
 
 logger = logging.getLogger("Pegasus")
 
@@ -4810,7 +4814,7 @@ def env_setup():
         path_entries.append("/usr/sbin")
 
     # fink on macos x
-    if os.path.exists("/sw/bin") and not ("/sw/bin" in path_entries):
+    if Path("/sw/bin").exists() and not ("/sw/bin" in path_entries):
         path_entries.append("/sw/bin")
 
     # PYTHONHOME can cause problems when we call out to other tools
@@ -4853,7 +4857,7 @@ def check_cred_fs_permissions(path):
     permissions. If left too open (for example after a transfer over GASS,
     chmod it to be readable only by us.
     """
-    if not os.path.exists(path):
+    if not Path(path).exists():
         raise Exception("Credential file %s does not exist" % (path))
     if (os.stat(path).st_mode & 0o777) != 0o600:
         logger.warning("%s found to have weak permissions. chmod to 0600." % (path))
@@ -4866,7 +4870,7 @@ def load_credentials():
     """
     if "PEGASUS_CREDENTIALS" in os.environ:
         logger.debug("Loading credentials from " + os.environ["PEGASUS_CREDENTIALS"])
-        if not os.path.isfile(os.environ["PEGASUS_CREDENTIALS"]):
+        if not Path(os.environ["PEGASUS_CREDENTIALS"]).is_file():
             raise RuntimeError(
                 "Credentials file does not exist: " + os.environ["PEGASUS_CREDENTIALS"]
             )
@@ -4892,7 +4896,7 @@ def verify_local_file(path):
     """
     makes sure a local file exists and is readable
     """
-    if not (os.path.exists(path)):
+    if not (Path(path).exists()):
         logger.error("Expected local file does not exist: " + path)
         return False
 
@@ -4911,13 +4915,13 @@ def prepare_local_dir(path):
     """
     makes sure a local path exists before putting files into it
     """
-    if not (os.path.exists(path)):
+    if not (Path(path).exists()):
         logger.debug("Creating local directory " + path)
         try:
             os.makedirs(path, 0o0755)
         except OSError as err:
             # if dir already exists, ignore the error
-            if not (os.path.isdir(path)):
+            if not (Path(path).is_dir()):
                 raise RuntimeError(err)
 
 

--- a/packages/pegasus-worker/src/Pegasus/transfer.py
+++ b/packages/pegasus-worker/src/Pegasus/transfer.py
@@ -3810,7 +3810,10 @@ class WebdavHandler(TransferHandlerBase):
                 url = re.sub("^webdav", "http", t.dst_url())
 
                 # might have to create dir first
-                self._create_dir(str(Path(url).parent), username, password)
+                # NB: url is a full URL (e.g. https://host/path); use
+                # os.path.dirname, not Path().parent, which would collapse the
+                # "//" in the scheme (https:// -> https:/) and corrupt the URL.
+                self._create_dir(os.path.dirname(url), username, password)
 
                 cmd = tools.full_path("curl")
                 if not logger.isEnabledFor(logging.DEBUG):


### PR DESCRIPTION
## Summary
- Replace os.path usage in packages Python code with pathlib Path usage
- Import Path directly with `from pathlib import Path`
- Enable Ruff PTH checks in package pyproject files
- Preserve Python 3.6 compatibility for pegasus-worker

Fixes #2215

## Validation
- tox -e py310 for pegasus-api, pegasus-common, pegasus-python, and pegasus-worker packages
- Ruff check/format for py3.10 packages
- Python 3.6 compileall for pegasus-worker
- Workflow tests triggered: https://scitech-gitlab.isi.edu/pegasus/pegasus/-/pipelines/4775