### PR TITLE
fix(ensembles): bound EM_PORT to a valid TCP port range

### DIFF
--- a/packages/pegasus-python/src/Pegasus/service/ensembles/commands.py
+++ b/packages/pegasus-python/src/Pegasus/service/ensembles/commands.py
@@ -15,7 +15,15 @@ from Pegasus.service.ensembles.trigger import TriggerManager
 
 log = logging.getLogger(__name__)
 
-EM_PORT = os.getuid() + 7919
+EM_PORT_MIN = 7919
+EM_PORT_MAX = 65535
+
+
+def _compute_em_port(uid: int) -> int:
+    return EM_PORT_MIN + (uid % (EM_PORT_MAX - EM_PORT_MIN))
+
+
+EM_PORT = _compute_em_port(os.getuid())
 
 
 class EnsembleClientCommand(Command):

--- a/packages/pegasus-python/test/service/ensembles/test_commands.py
+++ b/packages/pegasus-python/test/service/ensembles/test_commands.py
@@ -6,9 +6,19 @@ import pytest
 import Pegasus
 from Pegasus.db.ensembles import TriggerType
 from Pegasus.service.ensembles.commands import (
+    EM_PORT_MAX,
+    EM_PORT_MIN,
     CronTriggerCommand,
     FilePatternTriggerCommand,
+    _compute_em_port,
 )
+
+
+class TestEMPort:
+    @pytest.mark.parametrize("uid", [0, 1000, 57616, 100_000_000])
+    def test_em_port_is_within_valid_range(self, uid):
+        port = _compute_em_port(uid)
+        assert EM_PORT_MIN <= port < EM_PORT_MAX
 
 
 class TestCronTriggerCommand:


### PR DESCRIPTION
## Summary

- `EM_PORT = os.getuid() + 7919` in `Pegasus/service/ensembles/commands.py` could exceed
  65535, the max valid TCP port, on systems with large UIDs (e.g. LDAP/domain-assigned
  accounts on "big systems"). This broke both the server bind and the CLI client's URL
  parsing (`Failed to parse: http://127.0.0.1:108751/ensembles` in the reported traceback).
- Bounds the value into `[7919, 65535)` with modulo arithmetic, extracted into
  `_compute_em_port(uid)` for testability. For UIDs under ~57616 (the common case) behavior
  is unchanged.
- Added `TestEMPort` covering uid values 0, 1000, 57616 (the wrap boundary), and a huge UID.

## Note on e2e

e2e was intentionally **not** run for this branch before opening this PR, per explicit
request. `pegasus-python` unit tests pass locally (405 passed).

## Skipped review findings

- Consider moving `EM_PORT_MIN`/`EM_PORT_MAX` into `Pegasus.service.defaults` to match the
  existing `SERVER_PORT` config pattern — skipped, out of scope for this diff.
- The modulo scheme can still map two different UIDs to the same port (e.g. `uid` and
  `uid + 57616` collide) — skipped; issue #2016 only reports the out-of-range crash, not a
  collision from real usage. A collision-free fix would need a coordination mechanism (bind
  to an OS-assigned ephemeral port, persist it to a per-user file) — left as a possible
  follow-up, not implemented here.
- No test asserts uniqueness/non-collision across UIDs — skipped, same reasoning as above.

Closes #2016