### PR TITLE
fix(planner): use correct variable to guard when_to_transfer_output i…

### DIFF
--- a/src/edu/isi/pegasus/planner/code/generator/condor/style/CondorC.java
+++ b/src/edu/isi/pegasus/planner/code/generator/condor/style/CondorC.java
@@ -112,7 +112,7 @@ public class CondorC extends Condor {
 
             String w_t_f =
                     (String) job.condorVariables.removeKey(CondorC.WHEN_TO_TRANSFER_OUTPUT_KEY);
-            if (s_t_f != null) {
+            if (w_t_f != null) {
                 // convert to remote key and quote it
                 job.condorVariables.construct(
                         CondorC.REMOTE_WHEN_TO_TRANSFER_OUTPUT_KEY,


### PR DESCRIPTION
…n CondorC style

The null-check for remote_when_to_transfer_output reused s_t_f (should_transfer_files) instead of w_t_f (when_to_transfer_output), so the value used depended on the wrong condor key: it either embedded the literal string "null" (s_t_f set, w_t_f unset) or silently discarded the user's when_to_transfer_output value in favor of the "ON_EXIT" default (s_t_f unset, w_t_f set).

Refs #2229