### PR TITLE
monitord plugins: async lifecycle, shape-aware snapshots, opt-in coroutine plugins

### DIFF
--- a/doc/sphinx/reference-guide/monitoring.rst
+++ b/doc/sphinx/reference-guide/monitoring.rst
@@ -305,8 +305,8 @@ drops.
 
 -  Delivery is **best-effort**: the queue is bounded (drop-on-overflow,
    counted and logged, with a final per-plugin dropped total logged at
-   shutdown), workers are daemon threads, and shutdown joins are bounded
-   by ``join_timeout``. Which event is lost on overflow is configurable:
+   shutdown), workers are daemon threads, and worker joins are bounded by
+   ``join_timeout``. Which event is lost on overflow is configurable:
    ``drop-newest`` (default) drops the event being submitted, while
    ``overflow_policy = drop-oldest`` evicts the oldest queued event so a
    live-monitoring plugin keeps the freshest state — either way exactly
@@ -314,8 +314,9 @@ drops.
    raises, wedges, or falls behind is isolated and logged; it never
    blocks, grows, or kills monitord. If the worker does not exit within
    ``join_timeout``, ``stop()`` is skipped for that plugin because
-   ``handle_event()`` may still be running. If ``stop()`` itself does
-   not return within ``join_timeout``, Pegasus logs and continues exit.
+   ``handle_event()`` may still be running. A synchronous ``stop()`` that
+   does not return within ``join_timeout`` is abandoned; async cancellation
+   behavior is described below.
 
 -  A single monitord may process a root workflow and its sub-workflows;
    demultiplex on the ``xwf__id`` / ``root__xwf__id`` payload keys if
@@ -340,9 +341,10 @@ What async buys is *recoverable timeouts*: with
 of seconds, a handler call that exceeds it is **cancelled** and the worker
 moves on to the next event — where a wedged sync handler permanently costs
 its worker thread and its ``stop()`` cleanup. An ``async def stop()`` is
-likewise cancelled at ``join_timeout`` instead of being abandoned
-mid-call. With ``event_timeout`` unset (the default), async plugins behave
-exactly like sync ones, wedges included.
+cancelled at ``join_timeout`` and gets up to one additional
+``join_timeout`` to finish cooperative cancellation cleanup before its
+helper thread is abandoned. With ``event_timeout`` unset (the default),
+async event handlers behave exactly like sync ones, wedges included.
 
 Two caveats, both important:
 

--- a/doc/sphinx/reference-guide/monitoring.rst
+++ b/doc/sphinx/reference-guide/monitoring.rst
@@ -280,11 +280,12 @@ drops.
 
 **Threading and delivery contract.**
 
--  ``start()`` runs once during monitord startup in a bounded helper
-   thread. If it does not return within ``start_timeout``, Pegasus logs,
-   skips that plugin, and continues startup. Python cannot forcibly kill
-   the helper thread, so Pegasus attempts bounded ``stop()`` cleanup if a
-   timed-out ``start()`` returns later. ``handle_event()`` and ``tick()``
+-  The complete plugin bootstrap — entry-point loading, construction, and
+   ``start()`` — runs during monitord startup in a bounded helper thread.
+   If it does not complete within ``start_timeout``, Pegasus logs, skips
+   that plugin, and continues startup. Python cannot forcibly kill the
+   helper thread, so Pegasus attempts bounded ``stop()`` cleanup if a
+   timed-out bootstrap returns later. ``handle_event()`` and ``tick()``
    run on the plugin's own dedicated thread, so they never race each
    other and shared plugin state needs no locking. ``stop()`` runs once
    after the worker exits, in a bounded helper thread. When several

--- a/doc/sphinx/reference-guide/monitoring.rst
+++ b/doc/sphinx/reference-guide/monitoring.rst
@@ -411,6 +411,29 @@ A complete production example is the ``wfmonitor`` plugin in
 event stream into its native JSONL records and uses ``tick()`` to poll
 HTCondor alongside.
 
+**When not to run in-process: native, untrusted, or crash-isolated
+consumers.** In-process plugins are for **trusted, pure-Python** code.
+The host isolates plugins from monitord at the Python level — exceptions
+are swallowed, queues are bounded, every lifecycle wait carries a
+timeout — but no in-process safeguard can survive what happens *below*
+Python: a native-extension segfault kills the whole monitord process, an
+``os._exit()`` call skips every atexit drain, and a GIL-holding busy
+loop starves the parse loop itself. If your consumer links native code
+you do not fully trust, must not be able to take monitord down under any
+circumstance, or needs true CPU parallelism, run it **out of process**
+and use monitord's existing delivery mechanisms as the boundary:
+
+-  **AMQP**: point ``pegasus.catalog.workflow.amqp.url`` at a broker and
+   consume the event stream from any language, at any pace, in a process
+   whose crash monitord never notices. This is the sanctioned pattern
+   for untrusted consumers — the queue-plus-external-consumer split is
+   exactly the isolation an in-process plugin cannot get.
+-  **File tail**: a minimal trusted in-process plugin (or the
+   ``file://`` sink) writes events to a line-buffered file; the real
+   consumer tails it from its own process. This is the pattern the
+   ``wfmonitor`` plugin's JSONL output follows, and it adds
+   crash-replayability for free — the file is the durable hand-off.
+
 .. _stampede-schema-overview:
 
 Overview of the Workflow Database Schema.

--- a/doc/sphinx/reference-guide/monitoring.rst
+++ b/doc/sphinx/reference-guide/monitoring.rst
@@ -258,6 +258,7 @@ entry-point name:
    pegasus.monitord.plugins.myplugin.tick_interval  5       # >0 enables tick() (default 0 = no ticks)
    pegasus.monitord.plugins.myplugin.events          stampede.job_inst.,stampede.xwf.  # event-name prefixes; overrides the plugin's event_filter; '*' = all (default: all)
    pegasus.monitord.plugins.myplugin.overflow_policy drop-newest  # or drop-oldest: evict the oldest queued event instead (default drop-newest)
+   pegasus.monitord.plugins.myplugin.event_timeout  0       # >0 cancels an async handler call that exceeds it, seconds (default 0 = no bound; async plugins only)
    # any other key in the namespace is yours, via props.propertyset(...)
 
 If you enable a name that no installed package registers under the
@@ -325,6 +326,37 @@ drops.
    after an event once the interval has elapsed — and never after
    shutdown begins. It is the supported way to do wall-clock work (e.g.
    polling an external service) without a thread of your own.
+
+**Async plugins.** ``handle_event()``, ``tick()``, and ``stop()`` may each
+be declared ``async def`` — detected automatically, no configuration
+needed. Async handlers run on a private asyncio event loop owned by the
+plugin's worker thread (reach it with ``asyncio.get_running_loop()``);
+delivery stays strictly in order, one event at a time, and
+``handle_event()``/``tick()`` still never run concurrently, so the
+no-locking contract is unchanged.
+
+What async buys is *recoverable timeouts*: with
+``pegasus.monitord.plugins.<name>.event_timeout`` set to a positive number
+of seconds, a handler call that exceeds it is **cancelled** and the worker
+moves on to the next event — where a wedged sync handler permanently costs
+its worker thread and its ``stop()`` cleanup. An ``async def stop()`` is
+likewise cancelled at ``join_timeout`` instead of being abandoned
+mid-call. With ``event_timeout`` unset (the default), async plugins behave
+exactly like sync ones, wedges included.
+
+Two caveats, both important:
+
+-  Cancellation is **cooperative**. ``asyncio.CancelledError`` is raised
+   at the coroutine's next ``await`` — a coroutine that blocks in
+   synchronous code (``requests.get``, a stuck DB driver, a tight loop)
+   starves the loop and wedges the worker exactly like a blocking sync
+   handler. The timeout only protects handlers that actually ``await``
+   their slow work (e.g. ``aiohttp``, ``asyncio.to_thread`` is *not*
+   sufficient — the blocked thread survives cancellation).
+-  Write handlers **cancellation-safe**: cleanup belongs in ``finally``
+   (which runs on the worker thread), and a cancelled handler's partial
+   work must not corrupt your durable output — the same idempotency
+   thinking replay/recovery already requires.
 
 **Replay and recovery: the stream can be re-emitted from the beginning.**
 Two situations make ``pegasus-monitord`` re-read ``dagman.out`` from the

--- a/doc/sphinx/reference-guide/monitoring.rst
+++ b/doc/sphinx/reference-guide/monitoring.rst
@@ -286,7 +286,11 @@ drops.
    timed-out ``start()`` returns later. ``handle_event()`` and ``tick()``
    run on the plugin's own dedicated thread, so they never race each
    other and shared plugin state needs no locking. ``stop()`` runs once
-   after the worker exits, in a bounded helper thread.
+   after the worker exits, in a bounded helper thread. When several
+   plugins are enabled, different plugins start and stop concurrently
+   with one another (startup and shutdown are bounded by the slowest
+   plugin, not the sum); each plugin's own lifecycle stays strictly
+   ordered.
 
 -  Events are delivered to a single plugin **in order**; different
    plugins (and monitord's own database writer) run concurrently. Do not

--- a/packages/pegasus-python/src/Pegasus/cli/pegasus-monitord.py
+++ b/packages/pegasus-python/src/Pegasus/cli/pegasus-monitord.py
@@ -1143,6 +1143,11 @@ signal.signal(signal.SIGHUP, prog_sighup_handler)
 # Die nicely when asked to (Ctrl+C, system shutdown)
 signal.signal(signal.SIGINT, prog_sigint_handler)
 
+# Also exit gracefully on a plain "kill": SIGTERM's default action would skip
+# the atexit handlers that drain and close the event sinks (stampede DB flush,
+# monitord event plugins)
+signal.signal(signal.SIGTERM, prog_sigint_handler)
+
 # Permit dynamic changes of debug level
 signal.signal(signal.SIGUSR1, prog_sigusr1_handler)
 signal.signal(signal.SIGUSR2, prog_sigusr2_handler)

--- a/packages/pegasus-python/src/Pegasus/cli/pegasus-monitord.py
+++ b/packages/pegasus-python/src/Pegasus/cli/pegasus-monitord.py
@@ -1222,7 +1222,20 @@ else:
                 "error flushing previous wf_uuid from database... continuing..."
             )
             logger.error("cannot create events output... disabling event output!")
-            wf_event_sink = None
+            # The sink has already been constructed (and a multiplex sink may
+            # already have started plugin workers). Close it before clearing
+            # the global; finish_stampede_loader reads that global at atexit,
+            # so assigning None first would orphan the sink and skip every
+            # plugin's stop() cleanup.
+            try:
+                wf_event_sink.close()
+            except Exception:
+                logger.warning(
+                    "could not close workflow event output after purge failure"
+                )
+                logger.warning(traceback.format_exc())
+            finally:
+                wf_event_sink = None
 
     # create the stampede_dashboard_loader
     try:

--- a/packages/pegasus-python/src/Pegasus/monitoring/plugin.py
+++ b/packages/pegasus-python/src/Pegasus/monitoring/plugin.py
@@ -674,61 +674,150 @@ class MonitordPluginManager:
         """
         entry_points = self._discover_entry_points()
         self._warn_unmatched_enabled_names(entry_points)
-        enabled = list(self._iter_enabled_plugin_classes(entry_points))
+        enabled = list(self._iter_enabled_entry_points(entry_points))
         if len(enabled) <= 1:
-            results = [self._start_one(name, cls) for name, cls in enabled]
+            results = [
+                self._start_one(name, entry_point) for name, entry_point in enabled
+            ]
         else:
             results = self._fan_out(
                 "startup",
-                [(name, (name, cls)) for name, cls in enabled],
-                lambda name, cls: self._start_one(name, cls),
+                [(name, (name, entry_point)) for name, entry_point in enabled],
+                lambda name, entry_point: self._start_one(name, entry_point),
             )
         for item in results:
             if item is not None:
                 self._workers.append(item)
         return len(self._workers)
 
-    def _start_one(self, name, cls):
+    def _start_one(self, name, entry_point):
         """
-        Run one plugin's full startup sequence: config parse, instantiate,
-        bounded ``start()``, then spin up its worker. Returns the
-        ``(name, plugin, worker)`` triple, or ``None`` when the plugin is
-        skipped. Safe to run on a helper thread: everything it touches is
-        per-plugin, except the shared properties object, which is only read.
+        Run one plugin's complete bootstrap under ``start_timeout``: load the
+        entry point, construct the instance, call ``start()``, compile its
+        filter, and start its worker. Returns the ``(name, plugin, worker)``
+        triple, or ``None`` when the plugin is skipped.
+
+        Python cannot kill the helper thread. If a timed-out bootstrap returns
+        later, it observes ``timed_out`` and performs bounded cleanup without
+        publishing the plugin to the manager.
         """
-        plugin = None
-        worker = None
-        join_timeout = DEFAULT_JOIN_TIMEOUT
         try:
             cfg = self._worker_config(name)
-            join_timeout = cfg.join_timeout
-            plugin = cls()
-            if not self._start_plugin(name, plugin, cfg.start_timeout):
-                return None
-            # read from the instance after start() so plugins may derive
-            # their filter dynamically (e.g. from props) in start()
-            event_filter = self._compile_event_filter(name, cfg.events, plugin)
-            worker = _PluginWorker(
-                name,
-                plugin,
-                queue_size=cfg.queue_size,
-                join_timeout=cfg.join_timeout,
-                tick_interval=cfg.tick_interval,
-                event_filter=event_filter,
-                overflow_policy=cfg.overflow_policy,
-                event_timeout=cfg.event_timeout,
-            )
-            worker.start()
-            self._log.info("started monitord event plugin %r", name)
-            return (name, plugin, worker)
         except Exception:
             self._log.error(
-                "failed to start plugin %r; skipping\n%s",
+                "invalid configuration for plugin %r; skipping\n%s",
                 name,
                 traceback.format_exc(),
             )
-            self._cleanup_failed_start(name, plugin, worker, join_timeout)
             return None
+
+        done = Event()
+        timed_out = Event()
+        cleanup_lock = Lock()
+        cleanup_started = []
+        result = {
+            "plugin": None,
+            "worker": None,
+            "triple": None,
+            "traceback": None,
+        }
+
+        def cleanup_after_timeout():
+            with cleanup_lock:
+                if cleanup_started:
+                    return
+                cleanup_started.append(True)
+            if result["traceback"]:
+                self._log.error(
+                    "plugin %r bootstrap failed after startup timeout\n%s",
+                    name,
+                    result["traceback"],
+                )
+            elif result["plugin"] is not None:
+                self._log.warning(
+                    "plugin %r bootstrap returned after startup timeout; "
+                    "running stop() cleanup",
+                    name,
+                )
+            self._cleanup_failed_start(
+                name,
+                result["plugin"],
+                result["worker"],
+                cfg.join_timeout,
+            )
+
+        def bootstrap_target():
+            try:
+                cls = entry_point.load()
+                if timed_out.is_set():
+                    return
+                plugin = cls()
+                result["plugin"] = plugin
+                if timed_out.is_set():
+                    return
+                plugin.start(self._props, **self._start_kwargs(plugin))
+                if timed_out.is_set():
+                    return
+                # Read from the instance after start() so plugins may derive
+                # their filter dynamically (e.g. from props) in start().
+                event_filter = self._compile_event_filter(name, cfg.events, plugin)
+                if timed_out.is_set():
+                    return
+                worker = _PluginWorker(
+                    name,
+                    plugin,
+                    queue_size=cfg.queue_size,
+                    join_timeout=cfg.join_timeout,
+                    tick_interval=cfg.tick_interval,
+                    event_filter=event_filter,
+                    overflow_policy=cfg.overflow_policy,
+                    event_timeout=cfg.event_timeout,
+                )
+                result["worker"] = worker
+                if timed_out.is_set():
+                    return
+                worker.start()
+                result["triple"] = (name, plugin, worker)
+            except Exception:
+                result["traceback"] = traceback.format_exc()
+            finally:
+                done.set()
+                if timed_out.is_set():
+                    cleanup_after_timeout()
+
+        bootstrap_thread = Thread(
+            target=bootstrap_target,
+            name=f"monitord-plugin-{name}-start",
+            daemon=True,
+        )
+        bootstrap_thread.start()
+        bootstrap_thread.join(timeout=cfg.start_timeout)
+        if bootstrap_thread.is_alive():
+            timed_out.set()
+            self._log.warning(
+                "plugin %r bootstrap did not complete within %.1fs; skipping it",
+                name,
+                cfg.start_timeout,
+            )
+            if done.is_set():
+                cleanup_after_timeout()
+            return None
+        if result["traceback"]:
+            self._log.error(
+                "failed to start plugin %r; skipping\n%s",
+                name,
+                result["traceback"],
+            )
+            self._cleanup_failed_start(
+                name,
+                result["plugin"],
+                result["worker"],
+                cfg.join_timeout,
+            )
+            return None
+        if result["triple"] is not None:
+            self._log.info("started monitord event plugin %r", name)
+        return result["triple"]
 
     def _fan_out(self, stage, named_args, fn):
         """
@@ -739,9 +828,7 @@ class MonitordPluginManager:
         runs from monitord's atexit handler, where importing/creating an
         executor has interpreter-shutdown interplay that bare ``Thread`` +
         ``join`` (already used in this path today) does not. The joins carry
-        no timeout because every operation inside ``fn`` is itself bounded --
-        except code the plugin author controls (e.g. ``__init__``), which was
-        equally unbounded on the main thread before parallelization.
+        no timeout because every operation inside ``fn`` is itself bounded.
         """
         results = [None] * len(named_args)
 
@@ -858,76 +945,6 @@ class MonitordPluginManager:
             return
         if plugin is not None:
             self._stop_plugin(name, plugin, join_timeout, "startup cleanup")
-
-    def _start_plugin(self, name, plugin, timeout):
-        """
-        Run plugin.start() with a bounded wait. Timed-out plugins are skipped.
-        """
-        done = Event()
-        timed_out = Event()
-        cleanup_lock = Lock()
-        cleanup_started = []
-        result = {"ok": False, "traceback": None}
-        start_kwargs = self._start_kwargs(plugin)
-
-        def cleanup_after_timeout():
-            with cleanup_lock:
-                if cleanup_started:
-                    return
-                cleanup_started.append(True)
-            if result["traceback"]:
-                self._log.error(
-                    "plugin %r start() failed after startup timeout\n%s",
-                    name,
-                    result["traceback"],
-                )
-                context = "late startup failure cleanup"
-            else:
-                self._log.warning(
-                    "plugin %r start() returned after startup timeout; running stop() cleanup",
-                    name,
-                )
-                context = "late startup cleanup"
-            self._stop_plugin(name, plugin, timeout, context)
-
-        def start_target():
-            try:
-                plugin.start(self._props, **start_kwargs)
-            except Exception:
-                result["traceback"] = traceback.format_exc()
-            else:
-                result["ok"] = True
-            finally:
-                done.set()
-                if timed_out.is_set():
-                    cleanup_after_timeout()
-
-        start_thread = Thread(
-            target=start_target,
-            name=f"monitord-plugin-{name}-start",
-            daemon=True,
-        )
-        start_thread.start()
-        start_thread.join(timeout=timeout)
-        if start_thread.is_alive():
-            timed_out.set()
-            self._log.warning(
-                "plugin %r start() did not return within %.1fs; skipping it",
-                name,
-                timeout,
-            )
-            if done.is_set():
-                cleanup_after_timeout()
-            return False
-        if result["traceback"]:
-            self._log.error(
-                "failed to start plugin %r; skipping\n%s",
-                name,
-                result["traceback"],
-            )
-            self._stop_plugin(name, plugin, timeout, "startup failure cleanup")
-            return False
-        return True
 
     def _start_kwargs(self, plugin):
         """
@@ -1072,7 +1089,7 @@ class MonitordPluginManager:
         finally:
             loop.close()
 
-    def _iter_enabled_plugin_classes(self, entry_points):
+    def _iter_enabled_entry_points(self, entry_points):
         for name, ep in entry_points:
             if not self._is_enabled(name):
                 self._log.debug(
@@ -1082,16 +1099,7 @@ class MonitordPluginManager:
                     name,
                 )
                 continue
-            try:
-                cls = ep.load()
-            except Exception:
-                self._log.error(
-                    "failed to load plugin %r; skipping\n%s",
-                    name,
-                    traceback.format_exc(),
-                )
-                continue
-            yield name, cls
+            yield name, ep
 
     def _worker_config(self, name):
         queue_size = self._int_prop(

--- a/packages/pegasus-python/src/Pegasus/monitoring/plugin.py
+++ b/packages/pegasus-python/src/Pegasus/monitoring/plugin.py
@@ -64,6 +64,29 @@ DEFAULT_OVERFLOW_POLICY = OVERFLOW_DROP_NEWEST
 # Distinct from None, which could in principle be a queued value.
 _NOTHING = object()
 
+# Payload values of these EXACT types are immutable, so sharing them by
+# reference between the producer and every plugin is safe and skips
+# deepcopy's per-object machinery (deepcopy would return them by identity
+# anyway -- this is a cost cut, not a semantic change). Exact-type match
+# only: a subclass may carry mutable state, so it takes the deepcopy path.
+_IMMUTABLE_SCALAR_TYPES = frozenset({str, int, float, bool, bytes, type(None)})
+
+
+def _snapshot_payload(kw):
+    """
+    Per-plugin snapshot of an event payload: a new outer dict (the producer
+    reuses and rebinds keys in the original after dispatch), sharing
+    immutable scalar values by reference and deep-copying everything else
+    (nested mutables in composite events must not be aliased across
+    threads). Stampede payloads are overwhelmingly flat scalar dicts, so
+    this avoids most of a blanket ``copy.deepcopy(kw)``'s cost.
+    """
+    return {
+        key: val if type(val) in _IMMUTABLE_SCALAR_TYPES else copy.deepcopy(val)
+        for key, val in kw.items()
+    }
+
+
 _WorkerConfig = collections.namedtuple(
     "_WorkerConfig",
     "queue_size start_timeout join_timeout tick_interval events overflow_policy",
@@ -264,15 +287,17 @@ class _PluginWorker:
         payload snapshot below -- that is the entire point of filtering; they
         are counted separately and are not drops.
 
-        The payload is snapshotted with ``copy.deepcopy(kw)`` before it is
-        queued. The worker thread reads the payload asynchronously, while
+        The payload is snapshotted with :func:`_snapshot_payload` before it
+        is queued. The worker thread reads the payload asynchronously, while
         monitord's main thread keeps -- and in places reuses/mutates -- the
         original dict (e.g. the per-LFN ``rc.meta`` loop in ``workflow.py``
         overwrites ``key``/``value`` and re-sends the same dict; ``wf.plan``
-        adds ``db_url`` after the event is dispatched). A per-worker copy gives
-        each plugin its own isolated, stable payload and removes that
-        cross-thread data race, including nested mutable values in composite
-        events.
+        adds ``db_url`` after the event is dispatched). A per-worker snapshot
+        gives each plugin its own isolated, stable payload and removes that
+        cross-thread data race: the new outer dict decouples it from the
+        producer's key rebinding, immutable scalar values are shared by
+        reference, and everything else -- including nested mutable values in
+        composite events -- is deep-copied.
 
         On overflow, which event is lost depends on ``overflow_policy``:
         ``drop-newest`` (default) drops the event being submitted;
@@ -287,7 +312,7 @@ class _PluginWorker:
         if not self._thread.is_alive():
             return
         try:
-            payload = copy.deepcopy(kw)
+            payload = _snapshot_payload(kw)
         except Exception:
             if self._record_drop():
                 self._log.error(

--- a/packages/pegasus-python/src/Pegasus/monitoring/plugin.py
+++ b/packages/pegasus-python/src/Pegasus/monitoring/plugin.py
@@ -30,6 +30,7 @@ lives in :mod:`Pegasus.monitoring.event_output` as ``PluginHostEventSink``.
 #  limitations under the License.
 ##
 
+import asyncio
 import collections
 import copy
 import inspect
@@ -55,6 +56,7 @@ _ENABLED_SUFFIX = ".enabled"
 DEFAULT_QUEUE_SIZE = 10000
 DEFAULT_JOIN_TIMEOUT = 10.0
 DEFAULT_TICK_INTERVAL = 0.0  # 0 = no ticks; the worker blocks exactly as before
+DEFAULT_EVENT_TIMEOUT = 0.0  # 0 = no per-event bound (async plugins included)
 
 # Queue-overflow policies (pegasus.monitord.plugins.<name>.overflow_policy).
 OVERFLOW_DROP_NEWEST = "drop-newest"
@@ -89,8 +91,21 @@ def _snapshot_payload(kw):
 
 _WorkerConfig = collections.namedtuple(
     "_WorkerConfig",
-    "queue_size start_timeout join_timeout tick_interval events overflow_policy",
+    "queue_size start_timeout join_timeout tick_interval events overflow_policy"
+    " event_timeout",
 )
+
+
+def _is_coroutine_callable(fn):
+    """
+    True when ``fn`` is declared ``async def``. Degrades to False (the sync
+    dispatch path) on exotic callables that ``inspect`` cannot analyze,
+    mirroring the defensive signature sniffing in ``_start_kwargs``.
+    """
+    try:
+        return inspect.iscoroutinefunction(fn)
+    except (TypeError, ValueError):
+        return False
 
 
 def enabled_plugin_names(props):
@@ -195,6 +210,21 @@ class MonitordEventPlugin:
         :param kw: the event payload dict. Keys use ``__`` as the separator
             (e.g. ``xwf__id``, ``job__id``); the payload is passed through
             unmodified, exactly as monitord produced it.
+
+        May be declared ``async def``. An async handler runs on a private
+        asyncio event loop owned by this plugin's worker thread (reach it
+        with :func:`asyncio.get_running_loop`); events are still delivered
+        strictly in order, one at a time, and :meth:`tick` still never runs
+        concurrently. When ``pegasus.monitord.plugins.<name>.event_timeout``
+        is set to a positive number of seconds, a handler exceeding it is
+        **cancelled** and the worker moves on to the next event -- the one
+        recovery a blocked sync handler can never get. Cancellation is
+        *cooperative*: :class:`asyncio.CancelledError` is raised at the
+        coroutine's next ``await``, so code that blocks synchronously inside
+        a coroutine (e.g. ``requests.get``) starves the loop and wedges the
+        worker exactly like a blocking sync handler. Write handlers
+        cancellation-safe: cleanup belongs in ``finally``, which runs on the
+        worker thread.
         """
 
     def tick(self):
@@ -215,6 +245,10 @@ class MonitordEventPlugin:
         exceptions; a failing tick never kills the worker. ``tick()`` is never
         called after the shutdown sentinel has been drained, so it cannot race
         :meth:`stop`.
+
+        May be declared ``async def``; it then runs on the same private
+        event loop as an async :meth:`handle_event`, under the same
+        ``event_timeout`` bound, and the two still never run concurrently.
         """
 
     def stop(self):
@@ -224,6 +258,11 @@ class MonitordEventPlugin:
         ``join_timeout``, Pegasus skips ``stop()`` rather than racing cleanup
         against a still-running ``handle_event()``. If ``stop()`` itself does
         not return within ``join_timeout``, Pegasus logs and continues exit.
+
+        May be declared ``async def``: it is then driven on a throwaway
+        event loop under the same ``join_timeout`` bound, but a timeout
+        **cancels** the coroutine (cooperatively, like ``event_timeout``)
+        instead of abandoning the helper thread mid-call.
         """
 
 
@@ -251,6 +290,7 @@ class _PluginWorker:
         tick_interval=DEFAULT_TICK_INTERVAL,
         event_filter=None,
         overflow_policy=DEFAULT_OVERFLOW_POLICY,
+        event_timeout=DEFAULT_EVENT_TIMEOUT,
     ):
         self._name = name
         self._plugin = plugin
@@ -259,11 +299,19 @@ class _PluginWorker:
         self._tick_interval = tick_interval
         self._event_filter = event_filter
         self._overflow_policy = overflow_policy
+        self._event_timeout = event_timeout
+        # ``async def`` hooks are detected once here; async plugins get a
+        # private asyncio event loop owned by the worker thread (see _run)
+        self._handle_is_async = _is_coroutine_callable(plugin.handle_event)
+        self._tick_is_async = _is_coroutine_callable(plugin.tick)
+        self._loop = None
         # queue_size <= 0 means unbounded (matches queue.Queue default)
         maxsize = queue_size if queue_size and queue_size > 0 else 0
         self._queue = queue.Queue(maxsize=maxsize)
         self._dropped = 0
         self._filtered = 0
+        self._timed_out = 0
+        self._warned_sync_coroutine = False
         self._thread = Thread(
             target=self._run, name=f"monitord-plugin-{name}", daemon=True
         )
@@ -377,7 +425,14 @@ class _PluginWorker:
 
     def _handle(self, event, kw):
         try:
-            self._plugin.handle_event(event, kw)
+            if self._handle_is_async:
+                self._run_coroutine(
+                    self._plugin.handle_event(event, kw), f"handle_event({event})"
+                )
+            else:
+                ret = self._plugin.handle_event(event, kw)
+                if inspect.iscoroutine(ret):
+                    self._warn_sync_returned_coroutine("handle_event", ret)
         except Exception:
             # A misbehaving plugin must never kill its own thread.
             self._log.error(
@@ -389,7 +444,12 @@ class _PluginWorker:
 
     def _tick(self):
         try:
-            self._plugin.tick()
+            if self._tick_is_async:
+                self._run_coroutine(self._plugin.tick(), "tick()")
+            else:
+                ret = self._plugin.tick()
+                if inspect.iscoroutine(ret):
+                    self._warn_sync_returned_coroutine("tick", ret)
         except Exception:
             # Same isolation contract as handle_event: a failing tick is
             # logged, never fatal to the worker.
@@ -399,7 +459,65 @@ class _PluginWorker:
                 traceback.format_exc(),
             )
 
+    def _run_coroutine(self, coro, what):
+        """
+        Drive one plugin coroutine to completion on this worker's private
+        event loop (run_until_complete per event: per-plugin FIFO and the
+        no-concurrent-tick guarantee hold exactly as for sync plugins).
+        With a positive ``event_timeout``, a coroutine that exceeds it is
+        *cancelled* -- the worker survives and moves on to the next queued
+        item, instead of wedging forever the way a blocked sync handler
+        does. Cancellation is cooperative: it lands at the coroutine's next
+        ``await``, so synchronously-blocking code inside a coroutine still
+        wedges.
+        """
+        timeout = self._event_timeout
+        if not timeout or timeout <= 0:
+            self._loop.run_until_complete(coro)
+            return
+        try:
+            self._loop.run_until_complete(asyncio.wait_for(coro, timeout))
+        except asyncio.TimeoutError:
+            # wait_for has already cancelled the coroutine
+            self._timed_out += 1
+            self._log.error(
+                "plugin %r %s did not complete within %.1fs; cancelled "
+                "(%d cancelled so far)",
+                self._name,
+                what,
+                timeout,
+                self._timed_out,
+            )
+
+    def _warn_sync_returned_coroutine(self, hook, coro):
+        """A sync-declared hook returned a coroutine object: the plugin
+        author forgot ``async def``. Log once per worker and close the
+        coroutine so it neither runs nor warns about never being awaited."""
+        coro.close()
+        if self._warned_sync_coroutine:
+            return
+        self._warned_sync_coroutine = True
+        self._log.error(
+            "plugin %r %s() returned a coroutine but is not declared "
+            "'async def'; it will never run -- declare the hook async",
+            self._name,
+            hook,
+        )
+
     def _run(self):
+        if self._handle_is_async or self._tick_is_async:
+            # One private event loop for this worker thread's whole
+            # lifetime -- never a per-event asyncio.run(), which would tear
+            # the loop machinery down and up for every event. Handlers use
+            # asyncio.get_running_loop() to reach it.
+            self._loop = asyncio.new_event_loop()
+        try:
+            self._consume()
+        finally:
+            if self._loop is not None:
+                self._loop.close()
+
+    def _consume(self):
         interval = self._tick_interval
         if not interval or interval <= 0:
             # No ticks configured: block exactly as before (zero overhead).
@@ -466,6 +584,9 @@ class _PluginWorker:
                 self._name,
                 self._filtered,
             )
+        # _timed_out is written on the worker thread (unlike the two above);
+        # reading it here is safe only after the join below, so report it in
+        # a second pass at the end of this method.
         if not self._thread.is_alive():
             return True
         try:
@@ -484,6 +605,13 @@ class _PluginWorker:
                 self._join_timeout,
             )
             return False
+        # joined: the worker's _timed_out writes happened-before this read
+        if self._timed_out:
+            self._log.warning(
+                "plugin %r had %d handler call(s) cancelled on event_timeout",
+                self._name,
+                self._timed_out,
+            )
         return True
 
 
@@ -562,6 +690,7 @@ class MonitordPluginManager:
                 tick_interval=cfg.tick_interval,
                 event_filter=event_filter,
                 overflow_policy=cfg.overflow_policy,
+                event_timeout=cfg.event_timeout,
             )
             worker.start()
             self._log.info("started monitord event plugin %r", name)
@@ -794,12 +923,18 @@ class MonitordPluginManager:
     def _stop_plugin(self, name, plugin, timeout, context="shutdown"):
         """
         Run plugin.stop() with the same bound used for worker shutdown.
+        An ``async def stop()`` is driven on a throwaway event loop and, on
+        timeout, *cancelled* -- the helper thread then exits, instead of
+        being abandoned mid-call the way a blocked sync stop() is.
         """
         done = []
 
         def stop_target():
             try:
-                plugin.stop()
+                if _is_coroutine_callable(plugin.stop):
+                    self._run_stop_coroutine(name, plugin, timeout, context)
+                else:
+                    plugin.stop()
             except Exception:
                 self._log.error(
                     "plugin %r stop() failed during %s\n%s",
@@ -826,6 +961,30 @@ class MonitordPluginManager:
             )
             return False
         return bool(done)
+
+    def _run_stop_coroutine(self, name, plugin, timeout, context):
+        """
+        Drive an ``async def stop()`` on a throwaway event loop, bounded by
+        ``timeout`` when positive (a non-positive timeout keeps today's
+        join-only bound, like the sync path).
+        """
+        loop = asyncio.new_event_loop()
+        try:
+            if timeout and timeout > 0:
+                try:
+                    loop.run_until_complete(asyncio.wait_for(plugin.stop(), timeout))
+                except asyncio.TimeoutError:
+                    self._log.warning(
+                        "plugin %r async stop() did not complete within %.1fs "
+                        "during %s; cancelled",
+                        name,
+                        timeout,
+                        context,
+                    )
+            else:
+                loop.run_until_complete(plugin.stop())
+        finally:
+            loop.close()
 
     def _iter_enabled_plugin_classes(self, entry_points):
         for name, ep in entry_points:
@@ -864,6 +1023,10 @@ class MonitordPluginManager:
             f"pegasus.monitord.plugins.{name}.tick_interval",
             DEFAULT_TICK_INTERVAL,
         )
+        event_timeout = self._float_prop(
+            f"pegasus.monitord.plugins.{name}.event_timeout",
+            DEFAULT_EVENT_TIMEOUT,
+        )
         if start_timeout < 0:
             raise ValueError(
                 f"pegasus.monitord.plugins.{name}.start_timeout must be >= 0"
@@ -871,6 +1034,10 @@ class MonitordPluginManager:
         if join_timeout < 0:
             raise ValueError(
                 f"pegasus.monitord.plugins.{name}.join_timeout must be >= 0"
+            )
+        if event_timeout < 0:
+            raise ValueError(
+                f"pegasus.monitord.plugins.{name}.event_timeout must be >= 0"
             )
         events = None
         raw = self._raw_prop(f"pegasus.monitord.plugins.{name}.events", None)
@@ -900,6 +1067,7 @@ class MonitordPluginManager:
             tick_interval=tick_interval,
             events=events,
             overflow_policy=policy,
+            event_timeout=event_timeout,
         )
 
     def _compile_event_filter(self, name, prop_patterns, plugin):

--- a/packages/pegasus-python/src/Pegasus/monitoring/plugin.py
+++ b/packages/pegasus-python/src/Pegasus/monitoring/plugin.py
@@ -106,7 +106,10 @@ class MonitordEventPlugin:
 
     * :meth:`start` is called once before events flow, in a bounded helper
       thread during monitord startup. :meth:`stop` is called once after the
-      event worker exits, also in a bounded helper thread.
+      event worker exits, also in a bounded helper thread. When several
+      plugins are enabled, different plugins' ``start()`` (and ``stop()``)
+      hooks may run concurrently with one another; each plugin's own
+      lifecycle stays strictly ordered.
     * :meth:`handle_event` is called once per event on this plugin's *own*
       dedicated background thread. Events are delivered to a single plugin in
       order, but different plugins (and monitord's own database writer) run
@@ -419,10 +422,12 @@ class _PluginWorker:
         ``join_timeout``). Returns once the thread has exited or the timeout
         has elapsed. Logs a final total if any events were dropped.
         """
-        # _dropped/_filtered are written only by submit() and read only here;
-        # both run on monitord's main thread (dispatch via the sink's send,
-        # close via the atexit sink close), so no lock is needed and the
-        # totals are final.
+        # _dropped/_filtered are written only by submit() (monitord's main
+        # thread, via the sink's send) and read only here. close() may run on
+        # a per-plugin teardown helper thread, but every submit() has ceased
+        # before that helper is spawned and Thread.start() publishes all
+        # prior writes to it -- so no lock is needed and the totals are
+        # final.
         if self._dropped:
             self._log.warning(
                 "plugin %r dropped %d event(s) in total "
@@ -482,43 +487,101 @@ class MonitordPluginManager:
         the others or monitord itself. A name that is enabled in properties
         but not registered under the entry-point group is logged as a warning
         and skipped.
+
+        When more than one plugin is enabled, the per-plugin startup sequences
+        run concurrently (one helper thread each), so N slow ``start()``s cost
+        one ``start_timeout``, not N. Survivors are recorded in discovery
+        (entry-point) order regardless of completion order.
         """
         entry_points = self._discover_entry_points()
         self._warn_unmatched_enabled_names(entry_points)
-        for name, cls in self._iter_enabled_plugin_classes(entry_points):
-            plugin = None
-            worker = None
-            join_timeout = DEFAULT_JOIN_TIMEOUT
-            try:
-                cfg = self._worker_config(name)
-                join_timeout = cfg.join_timeout
-                plugin = cls()
-                if not self._start_plugin(name, plugin, cfg.start_timeout):
-                    plugin = None
-                    continue
-                # read from the instance after start() so plugins may derive
-                # their filter dynamically (e.g. from props) in start()
-                event_filter = self._compile_event_filter(name, cfg.events, plugin)
-                worker = _PluginWorker(
-                    name,
-                    plugin,
-                    queue_size=cfg.queue_size,
-                    join_timeout=cfg.join_timeout,
-                    tick_interval=cfg.tick_interval,
-                    event_filter=event_filter,
-                    overflow_policy=cfg.overflow_policy,
-                )
-                worker.start()
-                self._workers.append((name, plugin, worker))
-                self._log.info("started monitord event plugin %r", name)
-            except Exception:
-                self._log.error(
-                    "failed to start plugin %r; skipping\n%s",
-                    name,
-                    traceback.format_exc(),
-                )
-                self._cleanup_failed_start(name, plugin, worker, join_timeout)
+        enabled = list(self._iter_enabled_plugin_classes(entry_points))
+        if len(enabled) <= 1:
+            results = [self._start_one(name, cls) for name, cls in enabled]
+        else:
+            results = self._fan_out(
+                "startup",
+                [(name, (name, cls)) for name, cls in enabled],
+                lambda name, cls: self._start_one(name, cls),
+            )
+        for item in results:
+            if item is not None:
+                self._workers.append(item)
         return len(self._workers)
+
+    def _start_one(self, name, cls):
+        """
+        Run one plugin's full startup sequence: config parse, instantiate,
+        bounded ``start()``, then spin up its worker. Returns the
+        ``(name, plugin, worker)`` triple, or ``None`` when the plugin is
+        skipped. Safe to run on a helper thread: everything it touches is
+        per-plugin, except the shared properties object, which is only read.
+        """
+        plugin = None
+        worker = None
+        join_timeout = DEFAULT_JOIN_TIMEOUT
+        try:
+            cfg = self._worker_config(name)
+            join_timeout = cfg.join_timeout
+            plugin = cls()
+            if not self._start_plugin(name, plugin, cfg.start_timeout):
+                return None
+            # read from the instance after start() so plugins may derive
+            # their filter dynamically (e.g. from props) in start()
+            event_filter = self._compile_event_filter(name, cfg.events, plugin)
+            worker = _PluginWorker(
+                name,
+                plugin,
+                queue_size=cfg.queue_size,
+                join_timeout=cfg.join_timeout,
+                tick_interval=cfg.tick_interval,
+                event_filter=event_filter,
+                overflow_policy=cfg.overflow_policy,
+            )
+            worker.start()
+            self._log.info("started monitord event plugin %r", name)
+            return (name, plugin, worker)
+        except Exception:
+            self._log.error(
+                "failed to start plugin %r; skipping\n%s",
+                name,
+                traceback.format_exc(),
+            )
+            self._cleanup_failed_start(name, plugin, worker, join_timeout)
+            return None
+
+    def _fan_out(self, stage, named_args, fn):
+        """
+        Run ``fn(*args)`` once per ``(name, args)`` entry, each on its own
+        daemon helper thread, and return the results in input order.
+
+        Plain threads rather than a ``concurrent.futures`` pool: ``stop_all``
+        runs from monitord's atexit handler, where importing/creating an
+        executor has interpreter-shutdown interplay that bare ``Thread`` +
+        ``join`` (already used in this path today) does not. The joins carry
+        no timeout because every operation inside ``fn`` is itself bounded --
+        except code the plugin author controls (e.g. ``__init__``), which was
+        equally unbounded on the main thread before parallelization.
+        """
+        results = [None] * len(named_args)
+
+        def _task(idx, args):
+            results[idx] = fn(*args)
+
+        threads = [
+            Thread(
+                target=_task,
+                args=(idx, args),
+                name=f"monitord-plugin-{name}-{stage}",
+                daemon=True,
+            )
+            for idx, (name, args) in enumerate(named_args)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        return results
 
     def dispatch(self, event, kw):
         """
@@ -530,27 +593,45 @@ class MonitordPluginManager:
     def stop_all(self):
         """
         Drain and join every plugin worker, then call each plugin's ``stop()``
-        in a bounded helper thread. Ordering matches the contract: ``stop()``
-        starts only after the plugin's event thread has been joined.
+        in a bounded helper thread. Per-plugin ordering matches the contract:
+        ``stop()`` starts only after that plugin's event thread has been
+        joined. Different plugins tear down concurrently (one helper thread
+        each), so shutdown is bounded by the slowest plugin, not the sum.
         """
-        for name, plugin, worker in self._workers:
-            worker_exited = False
-            try:
-                worker_exited = worker.close()
-            except Exception:
-                self._log.error(
-                    "error closing worker for plugin %r\n%s",
-                    name,
-                    traceback.format_exc(),
-                )
-            if not worker_exited:
-                self._log.warning(
-                    "skipping plugin %r stop() because its worker is still running",
-                    name,
-                )
-                continue
-            self._stop_plugin(name, plugin, worker._join_timeout)
+        workers = self._workers
+        if len(workers) <= 1:
+            for name, plugin, worker in workers:
+                self._stop_one(name, plugin, worker)
+        else:
+            self._fan_out(
+                "teardown",
+                [(entry[0], entry) for entry in workers],
+                self._stop_one,
+            )
         self._workers = []
+
+    def _stop_one(self, name, plugin, worker):
+        """
+        Tear one plugin down: drain and join its worker, then run ``stop()``
+        -- skipped when the worker misses its join timeout, so cleanup never
+        races a still-running ``handle_event``.
+        """
+        worker_exited = False
+        try:
+            worker_exited = worker.close()
+        except Exception:
+            self._log.error(
+                "error closing worker for plugin %r\n%s",
+                name,
+                traceback.format_exc(),
+            )
+        if not worker_exited:
+            self._log.warning(
+                "skipping plugin %r stop() because its worker is still running",
+                name,
+            )
+            return
+        self._stop_plugin(name, plugin, worker._join_timeout)
 
     # ------------------------------------------------------------------ #
     # discovery / configuration helpers

--- a/packages/pegasus-python/src/Pegasus/monitoring/plugin.py
+++ b/packages/pegasus-python/src/Pegasus/monitoring/plugin.py
@@ -575,15 +575,26 @@ class MonitordPluginManager:
                 )
 
     def _cleanup_failed_start(self, name, plugin, worker, join_timeout):
+        worker_exited = True
         if worker is not None:
             try:
-                worker.close()
+                worker_exited = worker.close()
             except Exception:
+                worker_exited = False
                 self._log.error(
                     "error closing partially-started worker for plugin %r\n%s",
                     name,
                     traceback.format_exc(),
                 )
+        if not worker_exited:
+            # Same rule as stop_all: never race stop() against a worker that
+            # may still be inside handle_event.
+            self._log.warning(
+                "skipping plugin %r stop() during startup cleanup "
+                "because its worker is still running",
+                name,
+            )
+            return
         if plugin is not None:
             self._stop_plugin(name, plugin, join_timeout, "startup cleanup")
 

--- a/packages/pegasus-python/src/Pegasus/monitoring/plugin.py
+++ b/packages/pegasus-python/src/Pegasus/monitoring/plugin.py
@@ -83,10 +83,20 @@ def _snapshot_payload(kw):
     threads). Stampede payloads are overwhelmingly flat scalar dicts, so
     this avoids most of a blanket ``copy.deepcopy(kw)``'s cost.
     """
-    return {
-        key: val if type(val) in _IMMUTABLE_SCALAR_TYPES else copy.deepcopy(val)
-        for key, val in kw.items()
-    }
+    # Reuse one deepcopy memo for the whole payload so aliases and cycles
+    # spanning multiple top-level values retain the same object-graph shape
+    # as ``copy.deepcopy(kw)``. Seeding the memo with the new outer dict also
+    # preserves a nested reference back to the payload itself.
+    snapshot = {}
+    memo = {id(kw): snapshot}
+    for key, val in kw.items():
+        snapshot_key = (
+            key if type(key) in _IMMUTABLE_SCALAR_TYPES else copy.deepcopy(key, memo)
+        )
+        snapshot[snapshot_key] = (
+            val if type(val) in _IMMUTABLE_SCALAR_TYPES else copy.deepcopy(val, memo)
+        )
+    return snapshot
 
 
 _WorkerConfig = collections.namedtuple(
@@ -256,13 +266,14 @@ class MonitordEventPlugin:
         Called once after all events have been processed and this plugin's
         background thread has been joined. If the worker does not exit within
         ``join_timeout``, Pegasus skips ``stop()`` rather than racing cleanup
-        against a still-running ``handle_event()``. If ``stop()`` itself does
-        not return within ``join_timeout``, Pegasus logs and continues exit.
+        against a still-running ``handle_event()``. A synchronous ``stop()``
+        that does not return within ``join_timeout`` is abandoned; async
+        cancellation behavior is described below.
 
         May be declared ``async def``: it is then driven on a throwaway
-        event loop under the same ``join_timeout`` bound, but a timeout
-        **cancels** the coroutine (cooperatively, like ``event_timeout``)
-        instead of abandoning the helper thread mid-call.
+        event loop. After ``join_timeout`` the coroutine is **cancelled**;
+        Pegasus waits up to one additional ``join_timeout`` for cooperative
+        cancellation cleanup before abandoning the helper thread.
         """
 
 
@@ -433,6 +444,16 @@ class _PluginWorker:
                 ret = self._plugin.handle_event(event, kw)
                 if inspect.iscoroutine(ret):
                     self._warn_sync_returned_coroutine("handle_event", ret)
+        except asyncio.CancelledError:
+            # CancelledError inherits BaseException, not Exception. A plugin
+            # may legitimately receive it from an awaited child operation;
+            # letting it escape would silently kill this worker and strand
+            # every later event in the queue.
+            self._log.error(
+                "plugin %r handle_event(%s) was cancelled; continuing",
+                self._name,
+                event,
+            )
         except Exception:
             # A misbehaving plugin must never kill its own thread.
             self._log.error(
@@ -450,6 +471,11 @@ class _PluginWorker:
                 ret = self._plugin.tick()
                 if inspect.iscoroutine(ret):
                     self._warn_sync_returned_coroutine("tick", ret)
+        except asyncio.CancelledError:
+            self._log.error(
+                "plugin %r tick() was cancelled; continuing",
+                self._name,
+            )
         except Exception:
             # Same isolation contract as handle_event: a failing tick is
             # logged, never fatal to the worker.
@@ -923,18 +949,36 @@ class MonitordPluginManager:
     def _stop_plugin(self, name, plugin, timeout, context="shutdown"):
         """
         Run plugin.stop() with the same bound used for worker shutdown.
-        An ``async def stop()`` is driven on a throwaway event loop and, on
-        timeout, *cancelled* -- the helper thread then exits, instead of
-        being abandoned mid-call the way a blocked sync stop() is.
+        An ``async def stop()`` is driven on a throwaway event loop. It gets
+        one ``timeout`` interval to finish normally; if still running, the
+        host requests cancellation and waits one additional ``timeout`` for
+        cooperative cancellation cleanup before abandoning the helper.
         """
         done = []
+        async_stop = _is_coroutine_callable(plugin.stop)
+        cancel_requested = Event()
+        async_ready = Event()
+        async_state = {}
 
         def stop_target():
             try:
-                if _is_coroutine_callable(plugin.stop):
-                    self._run_stop_coroutine(name, plugin, timeout, context)
+                if async_stop:
+                    self._run_stop_coroutine(
+                        plugin,
+                        cancel_requested,
+                        async_ready,
+                        async_state,
+                    )
                 else:
                     plugin.stop()
+            except asyncio.CancelledError:
+                # A self-cancelling stop hook is a plugin failure, but it must
+                # not escape the helper thread as an unhandled BaseException.
+                self._log.error(
+                    "plugin %r stop() cancelled itself during %s",
+                    name,
+                    context,
+                )
             except Exception:
                 self._log.error(
                     "plugin %r stop() failed during %s\n%s",
@@ -952,6 +996,44 @@ class MonitordPluginManager:
         )
         stop_thread.start()
         stop_thread.join(timeout=timeout)
+        if not stop_thread.is_alive():
+            return bool(done)
+
+        if async_stop:
+            # Request cancellation from the controlling thread so it begins
+            # before _stop_plugin returns. An inner wait_for using the same
+            # timeout races this outer join and always loses that guarantee.
+            cancel_requested.set()
+            if async_ready.is_set():
+                loop = async_state.get("loop")
+                task = async_state.get("task")
+                if loop is not None and task is not None:
+                    try:
+                        loop.call_soon_threadsafe(task.cancel)
+                    except RuntimeError:
+                        # The task completed and closed its loop between the
+                        # liveness check and cancellation request.
+                        pass
+            stop_thread.join(timeout=timeout)
+            if not stop_thread.is_alive():
+                self._log.warning(
+                    "plugin %r async stop() exceeded %.1fs during %s; cancelled",
+                    name,
+                    timeout,
+                    context,
+                )
+                return bool(done)
+            self._log.warning(
+                "plugin %r async stop() did not finish within %.1fs during %s "
+                "and did not complete cancellation within another %.1fs; "
+                "abandoning it",
+                name,
+                timeout,
+                context,
+                timeout,
+            )
+            return False
+
         if stop_thread.is_alive():
             self._log.warning(
                 "plugin %r stop() did not return within %.1fs during %s; abandoning it",
@@ -962,27 +1044,31 @@ class MonitordPluginManager:
             return False
         return bool(done)
 
-    def _run_stop_coroutine(self, name, plugin, timeout, context):
+    def _run_stop_coroutine(
+        self,
+        plugin,
+        cancel_requested,
+        ready,
+        state,
+    ):
         """
-        Drive an ``async def stop()`` on a throwaway event loop, bounded by
-        ``timeout`` when positive (a non-positive timeout keeps today's
-        join-only bound, like the sync path).
+        Drive an ``async def stop()`` on a throwaway event loop. The caller
+        owns the timeout and requests cancellation through shared state so
+        the runtime bound and cancellation-grace bound cannot race each other.
         """
         loop = asyncio.new_event_loop()
+        task = loop.create_task(plugin.stop())
+        state["loop"] = loop
+        state["task"] = task
+        ready.set()
+        if cancel_requested.is_set():
+            task.cancel()
         try:
-            if timeout and timeout > 0:
-                try:
-                    loop.run_until_complete(asyncio.wait_for(plugin.stop(), timeout))
-                except asyncio.TimeoutError:
-                    self._log.warning(
-                        "plugin %r async stop() did not complete within %.1fs "
-                        "during %s; cancelled",
-                        name,
-                        timeout,
-                        context,
-                    )
-            else:
-                loop.run_until_complete(plugin.stop())
+            try:
+                loop.run_until_complete(task)
+            except asyncio.CancelledError:
+                if not cancel_requested.is_set():
+                    raise
         finally:
             loop.close()
 

--- a/packages/pegasus-python/test/test_monitord_plugin.py
+++ b/packages/pegasus-python/test/test_monitord_plugin.py
@@ -3,6 +3,7 @@ Tests for the pegasus-monitord plugin system (Pegasus.monitoring.plugin) and
 its host sink (Pegasus.monitoring.event_output.PluginHostEventSink).
 """
 
+import asyncio
 import copy
 import importlib.metadata
 import logging
@@ -1924,3 +1925,286 @@ def test_snapshot_failure_counts_as_drop_and_never_raises(monkeypatch):
     assert _wait_for(lambda: len(plugin.events) == 1)
     mgr.stop_all()
     assert plugin.events == [("stampede.good", {"xwf__id": "abc"})]
+
+
+# --------------------------------------------------------------------------- #
+# async plugins — opt-in coroutine handlers, event_timeout cancellation,
+# async stop(); the sync contract pinned elsewhere in this file is untouched
+# --------------------------------------------------------------------------- #
+
+
+class AsyncRecordingPlugin(MonitordEventPlugin):
+    def __init__(self):
+        self.events = []
+        self.ticks = []
+        self.stopped = False
+
+    async def handle_event(self, event, kw):
+        await asyncio.sleep(0)
+        self.events.append((event, dict(kw)))
+
+    async def tick(self):
+        await asyncio.sleep(0)
+        self.ticks.append(time.monotonic())
+
+    def stop(self):
+        self.stopped = True
+
+
+class AsyncFlakyPlugin(MonitordEventPlugin):
+    def __init__(self):
+        self.events = []
+
+    async def handle_event(self, event, kw):
+        if event == "stampede.bad":
+            raise ValueError("bad async event")
+        self.events.append(event)
+
+
+class AsyncHangingPlugin(MonitordEventPlugin):
+    """handle_event for the designated event awaits an asyncio.Event that is
+    never set by the plugin itself (a test can release it cross-thread via
+    loop.call_soon_threadsafe for cleanup)."""
+
+    def __init__(self):
+        self.entered = threading.Event()
+        self.events = []
+        self.cancelled = 0
+        self.finally_ran = 0
+        self.stopped = False
+        self.loop = None
+        self.release = None
+
+    async def handle_event(self, event, kw):
+        if event == "stampede.hang":
+            self.loop = asyncio.get_running_loop()
+            self.release = asyncio.Event()
+            self.entered.set()
+            try:
+                await self.release.wait()
+            except asyncio.CancelledError:
+                self.cancelled += 1
+                raise
+            finally:
+                self.finally_ran += 1
+        else:
+            self.events.append(event)
+
+    def stop(self):
+        self.stopped = True
+
+
+class AsyncStopPlugin(MonitordEventPlugin):
+    def __init__(self):
+        self.stopped = False
+
+    async def stop(self):
+        await asyncio.sleep(0)
+        self.stopped = True
+
+
+class HangingAsyncStopPlugin(MonitordEventPlugin):
+    def __init__(self):
+        self.stop_entered = threading.Event()
+        self.stop_cancelled = threading.Event()
+
+    async def stop(self):
+        self.stop_entered.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.stop_cancelled.set()
+            raise
+
+
+class SyncReturnsCoroutinePlugin(MonitordEventPlugin):
+    """The author forgot 'async def': a sync-declared handler returning a
+    coroutine object."""
+
+    def __init__(self):
+        self.ran = threading.Event()
+
+    def handle_event(self, event, kw):
+        async def never():
+            self.ran.set()
+
+        return never()
+
+
+def test_async_events_delivered_verbatim_in_order(monkeypatch):
+    _patch_entry_points(monkeypatch, {"arec": AsyncRecordingPlugin})
+    props = _props({"pegasus.monitord.plugins.arec.enabled": "true"})
+    mgr = MonitordPluginManager(props)
+    mgr.discover_and_start()
+    plugin = mgr._workers[0][1]
+
+    sent = [
+        ("stampede.wf.plan", {"xwf__id": "abc", "dax__label": "diamond"}),
+        ("stampede.job_inst.main.end", {"xwf__id": "abc", "exitcode": 0}),
+    ]
+    for event, kw in sent:
+        mgr.dispatch(event, kw)
+
+    assert _wait_for(lambda: len(plugin.events) == len(sent))
+    mgr.stop_all()
+    # same FIFO delivery contract as the sync mirror of this test
+    assert plugin.events == sent
+    assert plugin.stopped is True
+
+
+def test_async_handler_exception_is_swallowed(monkeypatch):
+    _patch_entry_points(monkeypatch, {"aflaky": AsyncFlakyPlugin})
+    props = _props({"pegasus.monitord.plugins.aflaky.enabled": "true"})
+    mgr = MonitordPluginManager(props)
+    mgr.discover_and_start()
+    plugin = mgr._workers[0][1]
+    worker = mgr._workers[0][2]
+
+    mgr.dispatch("stampede.bad", {})  # raises inside the coroutine
+    mgr.dispatch("stampede.good", {})
+
+    assert _wait_for(lambda: plugin.events == ["stampede.good"])
+    assert worker._thread.is_alive()
+    mgr.stop_all()
+
+
+def test_async_ticks_interleave_and_events_flow(monkeypatch):
+    _patch_entry_points(monkeypatch, {"atick": AsyncRecordingPlugin})
+    props = _props(
+        {
+            "pegasus.monitord.plugins.atick.enabled": "true",
+            "pegasus.monitord.plugins.atick.tick_interval": "0.05",
+        }
+    )
+    mgr = MonitordPluginManager(props)
+    mgr.discover_and_start()
+    plugin = mgr._workers[0][1]
+
+    assert _wait_for(lambda: len(plugin.ticks) >= 1)  # idle async ticks fire
+    n = 5
+    for i in range(n):
+        mgr.dispatch(f"stampede.e{i}", {})
+    assert _wait_for(lambda: len(plugin.events) == n)
+    mgr.stop_all()
+    assert [e for e, _kw in plugin.events] == [f"stampede.e{i}" for i in range(n)]
+    assert plugin.stopped is True
+
+
+def test_event_timeout_cancels_hung_async_handler_and_worker_survives(monkeypatch):
+    _patch_entry_points(monkeypatch, {"ahang": AsyncHangingPlugin})
+    props = _props(
+        {
+            "pegasus.monitord.plugins.ahang.enabled": "true",
+            "pegasus.monitord.plugins.ahang.event_timeout": "0.2",
+        }
+    )
+    mgr = MonitordPluginManager(props)
+    mgr.discover_and_start()
+    plugin = mgr._workers[0][1]
+    worker = mgr._workers[0][2]
+
+    mgr.dispatch("stampede.hang", {})
+    assert plugin.entered.wait(timeout=2)
+    mgr.dispatch("stampede.after", {})
+
+    # the hung handler is cancelled and the worker moves on to the next event
+    assert _wait_for(lambda: plugin.events == ["stampede.after"], timeout=5.0)
+    assert plugin.cancelled == 1
+    assert plugin.finally_ran == 1
+
+    # and shutdown completes fully: sentinel drains, worker exits, stop()
+    # runs -- the recovery a wedged sync handler can never get
+    mgr.stop_all()
+    assert plugin.stopped is True
+    assert not worker._thread.is_alive()
+    assert worker._timed_out == 1
+
+
+def test_async_handler_without_event_timeout_wedges_like_sync(monkeypatch):
+    _patch_entry_points(monkeypatch, {"ahang": AsyncHangingPlugin})
+    props = _props(
+        {
+            "pegasus.monitord.plugins.ahang.enabled": "true",
+            "pegasus.monitord.plugins.ahang.join_timeout": "0.01",
+        }
+    )
+    mgr = MonitordPluginManager(props)
+    mgr.discover_and_start()
+    plugin = mgr._workers[0][1]
+    worker = mgr._workers[0][2]
+
+    mgr.dispatch("stampede.hang", {})
+    assert plugin.entered.wait(timeout=2)
+
+    mgr.stop_all()
+    # default event_timeout=0: exactly today's abandonment semantics
+    # (mirror of test_stop_is_skipped_when_worker_misses_join_timeout)
+    assert worker._thread.is_alive()
+    assert plugin.stopped is False
+
+    # test hygiene: release the coroutine cross-thread so the worker drains
+    # the already-enqueued sentinel and exits
+    plugin.loop.call_soon_threadsafe(plugin.release.set)
+    assert _wait_for(lambda: not worker._thread.is_alive())
+
+
+def test_sync_handler_returning_coroutine_logged_once_never_runs(monkeypatch, caplog):
+    _patch_entry_points(monkeypatch, {"oops": SyncReturnsCoroutinePlugin})
+    props = _props({"pegasus.monitord.plugins.oops.enabled": "true"})
+    mgr = MonitordPluginManager(props)
+    mgr.discover_and_start()
+    plugin = mgr._workers[0][1]
+
+    with caplog.at_level(logging.ERROR):
+        mgr.dispatch("stampede.e0", {})
+        mgr.dispatch("stampede.e1", {})
+        mgr.stop_all()  # drains both events ahead of the sentinel
+
+    complaints = [r for r in caplog.records if "returned a coroutine" in r.message]
+    assert len(complaints) == 1  # logged once per worker, not per event
+    assert not plugin.ran.is_set()  # closed, never executed
+
+
+def test_async_stop_runs_to_completion(monkeypatch):
+    _patch_entry_points(monkeypatch, {"astop": AsyncStopPlugin})
+    props = _props({"pegasus.monitord.plugins.astop.enabled": "true"})
+    mgr = MonitordPluginManager(props)
+    mgr.discover_and_start()
+    plugin = mgr._workers[0][1]
+    mgr.stop_all()
+    assert plugin.stopped is True
+
+
+def test_async_stop_cancelled_at_timeout(monkeypatch):
+    _patch_entry_points(monkeypatch, {"astophang": HangingAsyncStopPlugin})
+    props = _props(
+        {
+            "pegasus.monitord.plugins.astophang.enabled": "true",
+            "pegasus.monitord.plugins.astophang.join_timeout": "0.2",
+        }
+    )
+    mgr = MonitordPluginManager(props)
+    mgr.discover_and_start()
+    plugin = mgr._workers[0][1]
+
+    mgr.stop_all()
+    assert plugin.stop_entered.wait(timeout=1)
+    # the hung async stop() is cancelled and its helper thread exits -- the
+    # sync path would leave it blocked forever on an abandoned thread
+    assert plugin.stop_cancelled.wait(timeout=2)
+
+
+def test_invalid_event_timeout_skips_plugin_before_start(monkeypatch):
+    CountingStartPlugin.started = 0
+    CountingStartPlugin.stopped = 0
+    _patch_entry_points(monkeypatch, {"badet": CountingStartPlugin})
+    props = _props(
+        {
+            "pegasus.monitord.plugins.badet.enabled": "true",
+            "pegasus.monitord.plugins.badet.event_timeout": "-1",
+        }
+    )
+    mgr = MonitordPluginManager(props)
+    assert mgr.discover_and_start() == 0
+    assert mgr._workers == []
+    assert CountingStartPlugin.started == 0

--- a/packages/pegasus-python/test/test_monitord_plugin.py
+++ b/packages/pegasus-python/test/test_monitord_plugin.py
@@ -1680,6 +1680,125 @@ def test_single_producer_all_enqueues_on_dispatching_thread():
 
 
 # --------------------------------------------------------------------------- #
+# parallel lifecycle — plugins start and stop concurrently, in discovery order
+# --------------------------------------------------------------------------- #
+
+
+class BarrierStartPlugin(MonitordEventPlugin):
+    """start() blocks until BOTH instances are inside start() -- possible
+    only when the manager runs plugin startups concurrently."""
+
+    barrier = None  # threading.Barrier(2), installed by the test
+
+    def __init__(self):
+        self.stopped = False
+
+    def start(self, props=None):
+        type(self).barrier.wait(timeout=5)  # BrokenBarrierError under serial
+
+    def stop(self):
+        self.stopped = True
+
+
+class BarrierStopPlugin(MonitordEventPlugin):
+    """stop() blocks until BOTH instances are inside stop()."""
+
+    barrier = None
+
+    def __init__(self):
+        self.stopped = False
+
+    def stop(self):
+        type(self).barrier.wait(timeout=5)
+        self.stopped = True
+
+
+class WaitsForPeerStartPlugin(MonitordEventPlugin):
+    """start() completes only after the peer plugin's start() has finished."""
+
+    peer_done = None  # threading.Event, installed by the test
+
+    def start(self, props=None):
+        type(self).peer_done.wait(timeout=5)
+
+
+class SignalsPeerStartPlugin(MonitordEventPlugin):
+    peer_done = None
+
+    def start(self, props=None):
+        type(self).peer_done.set()
+
+
+def test_plugins_start_concurrently(monkeypatch):
+    BarrierStartPlugin.barrier = threading.Barrier(2)
+    _patch_entry_points(
+        monkeypatch, {"p1": BarrierStartPlugin, "p2": BarrierStartPlugin}
+    )
+    props = _props(
+        {
+            "pegasus.monitord.plugins.p1.enabled": "true",
+            "pegasus.monitord.plugins.p2.enabled": "true",
+            # keeps the failure mode fast if startup regresses to serial
+            "pegasus.monitord.plugins.p1.start_timeout": "1",
+            "pegasus.monitord.plugins.p2.start_timeout": "1",
+        }
+    )
+    mgr = MonitordPluginManager(props)
+    # serial startup would break the barrier and start at most one plugin
+    assert mgr.discover_and_start() == 2
+    assert [name for name, _p, _w in mgr._workers] == ["p1", "p2"]
+    mgr.stop_all()
+
+
+def test_plugins_stop_concurrently(monkeypatch):
+    BarrierStopPlugin.barrier = threading.Barrier(2)
+    _patch_entry_points(monkeypatch, {"p1": BarrierStopPlugin, "p2": BarrierStopPlugin})
+    props = _props(
+        {
+            "pegasus.monitord.plugins.p1.enabled": "true",
+            "pegasus.monitord.plugins.p2.enabled": "true",
+            "pegasus.monitord.plugins.p1.join_timeout": "2",
+            "pegasus.monitord.plugins.p2.join_timeout": "2",
+        }
+    )
+    mgr = MonitordPluginManager(props)
+    assert mgr.discover_and_start() == 2
+    plugins = [p for _n, p, _w in mgr._workers]
+
+    start = time.monotonic()
+    mgr.stop_all()
+    elapsed = time.monotonic() - start
+    # serial teardown would park p1's stop() on the barrier for the full
+    # 2s join_timeout before p2's stop() could release it
+    assert elapsed < 1.0, f"stop_all took {elapsed:.2f}s; teardown ran serially?"
+    assert all(p.stopped for p in plugins)
+
+
+def test_workers_keep_discovery_order_regardless_of_completion(monkeypatch):
+    gate = threading.Event()
+    WaitsForPeerStartPlugin.peer_done = gate
+    SignalsPeerStartPlugin.peer_done = gate
+    # discovery order: pa first -- but its start() finishes only after pb's
+    _patch_entry_points(
+        monkeypatch,
+        {"pa": WaitsForPeerStartPlugin, "pb": SignalsPeerStartPlugin},
+    )
+    props = _props(
+        {
+            "pegasus.monitord.plugins.pa.enabled": "true",
+            "pegasus.monitord.plugins.pb.enabled": "true",
+            "pegasus.monitord.plugins.pa.start_timeout": "2",
+            "pegasus.monitord.plugins.pb.start_timeout": "2",
+        }
+    )
+    mgr = MonitordPluginManager(props)
+    assert mgr.discover_and_start() == 2
+    # completion order was pb-then-pa; _workers order must stay pa, pb
+    assert [name for name, _p, _w in mgr._workers] == ["pa", "pb"]
+    mgr.stop_all()
+
+
+# --------------------------------------------------------------------------- #
 # startup-failure cleanup must not race a still-running worker
 # --------------------------------------------------------------------------- #
 

--- a/packages/pegasus-python/test/test_monitord_plugin.py
+++ b/packages/pegasus-python/test/test_monitord_plugin.py
@@ -1877,6 +1877,18 @@ def test_snapshot_payload_semantics():
     assert snap["d"]["nested"] is not src["d"]["nested"]
 
 
+def test_snapshot_preserves_aliases_and_cycles_across_top_level_values():
+    shared = []
+    src = {"a": shared, "b": shared}
+    src["self"] = src
+
+    snap = _snapshot_payload(src)
+
+    assert snap["a"] is snap["b"]
+    assert snap["a"] is not shared
+    assert snap["self"] is snap
+
+
 def test_snapshot_skips_deepcopy_machinery_for_scalars(monkeypatch):
     deepcopied = []
     real_deepcopy = copy.deepcopy
@@ -2031,6 +2043,26 @@ class SyncReturnsCoroutinePlugin(MonitordEventPlugin):
         return never()
 
 
+class AsyncSelfCancellingPlugin(MonitordEventPlugin):
+    def __init__(self):
+        self.events = []
+
+    async def handle_event(self, event, kw):
+        if event == "stampede.cancel":
+            raise asyncio.CancelledError
+        self.events.append(event)
+
+
+class AsyncSelfCancellingTickPlugin(MonitordEventPlugin):
+    def __init__(self):
+        self.tick_calls = 0
+
+    async def tick(self):
+        self.tick_calls += 1
+        if self.tick_calls == 1:
+            raise asyncio.CancelledError
+
+
 def test_async_events_delivered_verbatim_in_order(monkeypatch):
     _patch_entry_points(monkeypatch, {"arec": AsyncRecordingPlugin})
     props = _props({"pegasus.monitord.plugins.arec.enabled": "true"})
@@ -2064,6 +2096,40 @@ def test_async_handler_exception_is_swallowed(monkeypatch):
     mgr.dispatch("stampede.good", {})
 
     assert _wait_for(lambda: plugin.events == ["stampede.good"])
+    assert worker._thread.is_alive()
+    mgr.stop_all()
+
+
+def test_async_handler_cancelled_error_is_swallowed(monkeypatch):
+    _patch_entry_points(monkeypatch, {"acancel": AsyncSelfCancellingPlugin})
+    props = _props({"pegasus.monitord.plugins.acancel.enabled": "true"})
+    mgr = MonitordPluginManager(props)
+    mgr.discover_and_start()
+    plugin = mgr._workers[0][1]
+    worker = mgr._workers[0][2]
+
+    mgr.dispatch("stampede.cancel", {})
+    mgr.dispatch("stampede.after", {})
+
+    assert _wait_for(lambda: plugin.events == ["stampede.after"])
+    assert worker._thread.is_alive()
+    mgr.stop_all()
+
+
+def test_async_tick_cancelled_error_is_swallowed(monkeypatch):
+    _patch_entry_points(monkeypatch, {"atcancel": AsyncSelfCancellingTickPlugin})
+    props = _props(
+        {
+            "pegasus.monitord.plugins.atcancel.enabled": "true",
+            "pegasus.monitord.plugins.atcancel.tick_interval": "0.01",
+        }
+    )
+    mgr = MonitordPluginManager(props)
+    mgr.discover_and_start()
+    plugin = mgr._workers[0][1]
+    worker = mgr._workers[0][2]
+
+    assert _wait_for(lambda: plugin.tick_calls >= 2)
     assert worker._thread.is_alive()
     mgr.stop_all()
 
@@ -2188,10 +2254,14 @@ def test_async_stop_cancelled_at_timeout(monkeypatch):
     plugin = mgr._workers[0][1]
 
     mgr.stop_all()
-    assert plugin.stop_entered.wait(timeout=1)
-    # the hung async stop() is cancelled and its helper thread exits -- the
-    # sync path would leave it blocked forever on an abandoned thread
-    assert plugin.stop_cancelled.wait(timeout=2)
+    # Cancellation is complete before stop_all returns, rather than racing a
+    # same-length outer join and happening later on an abandoned daemon thread.
+    assert plugin.stop_entered.is_set()
+    assert plugin.stop_cancelled.is_set()
+    assert not any(
+        t.name == "monitord-plugin-astophang-stop" and t.is_alive()
+        for t in threading.enumerate()
+    )
 
 
 def test_invalid_event_timeout_skips_plugin_before_start(monkeypatch):

--- a/packages/pegasus-python/test/test_monitord_plugin.py
+++ b/packages/pegasus-python/test/test_monitord_plugin.py
@@ -3,6 +3,7 @@ Tests for the pegasus-monitord plugin system (Pegasus.monitoring.plugin) and
 its host sink (Pegasus.monitoring.event_output.PluginHostEventSink).
 """
 
+import copy
 import importlib.metadata
 import logging
 import queue
@@ -16,6 +17,7 @@ from Pegasus.monitoring.plugin import (
     MonitordEventPlugin,
     MonitordPluginManager,
     _PluginWorker,
+    _snapshot_payload,
     enabled_plugin_names,
 )
 from Pegasus.tools import properties
@@ -1835,3 +1837,90 @@ def test_cleanup_failed_start_stops_plugin_after_worker_exit():
     # idle worker exits within the bound, so cleanup still runs stop()
     assert plugin.stopped is True
     assert not worker._thread.is_alive()
+
+
+# --------------------------------------------------------------------------- #
+# shape-aware payload snapshot — scalars shared by reference, containers
+# deep-copied; observable isolation semantics identical to a blanket deepcopy
+# --------------------------------------------------------------------------- #
+
+
+class _MutableStr(str):
+    """A str subclass can carry mutable state, so the exact-type scalar
+    gate must NOT share it by reference."""
+
+
+class _ExplodingValue:
+    def __deepcopy__(self, memo):
+        raise RuntimeError("cannot copy this value")
+
+
+def test_snapshot_payload_semantics():
+    src = {
+        "s": "str",
+        "i": 7,
+        "f": 1.5,
+        "b": True,
+        "by": b"x",
+        "n": None,
+        "lst": [1, {"k": "v"}],
+        "d": {"nested": [2]},
+    }
+    snap = _snapshot_payload(src)
+    assert snap == src
+    assert snap is not src  # new outer dict: producer key rebinding is safe
+    # containers are deep-copied, all the way down
+    assert snap["lst"] is not src["lst"]
+    assert snap["lst"][1] is not src["lst"][1]
+    assert snap["d"] is not src["d"]
+    assert snap["d"]["nested"] is not src["d"]["nested"]
+
+
+def test_snapshot_skips_deepcopy_machinery_for_scalars(monkeypatch):
+    deepcopied = []
+    real_deepcopy = copy.deepcopy
+
+    def recording_deepcopy(obj, *args, **kwargs):
+        deepcopied.append(obj)
+        return real_deepcopy(obj, *args, **kwargs)
+
+    monkeypatch.setattr(copy, "deepcopy", recording_deepcopy)
+
+    # an all-scalar payload (the overwhelmingly common shape) never touches
+    # deepcopy at all
+    _snapshot_payload({"xwf__id": "abc", "exitcode": 0, "site": None})
+    assert deepcopied == []
+
+    # only the non-scalar values go through deepcopy, not the outer dict
+    nested = {"attempts": [1]}
+    _snapshot_payload({"xwf__id": "abc", "multipart": nested})
+    assert deepcopied == [nested]
+
+
+def test_snapshot_copies_scalar_subclasses():
+    tainted = _MutableStr("looks like a str")
+    tainted.attached = ["mutable state"]
+    snap = _snapshot_payload({"v": tainted})
+    assert snap["v"] is not tainted
+    assert snap["v"] == tainted
+    assert snap["v"].attached is not tainted.attached
+
+
+def test_snapshot_failure_counts_as_drop_and_never_raises(monkeypatch):
+    _patch_entry_points(monkeypatch, {"rec": RecordingPlugin})
+    props = _props({"pegasus.monitord.plugins.rec.enabled": "true"})
+    mgr = MonitordPluginManager(props)
+    mgr.discover_and_start()
+    plugin = mgr._workers[0][1]
+    worker = mgr._workers[0][2]
+
+    # a payload value that cannot be snapshotted is a counted drop, never an
+    # exception into the dispatching (parse) loop
+    mgr.dispatch("stampede.bad", {"boom": _ExplodingValue()})
+    assert worker._dropped == 1
+
+    # and the worker is unharmed: the next event flows normally
+    mgr.dispatch("stampede.good", {"xwf__id": "abc"})
+    assert _wait_for(lambda: len(plugin.events) == 1)
+    mgr.stop_all()
+    assert plugin.events == [("stampede.good", {"xwf__id": "abc"})]

--- a/packages/pegasus-python/test/test_monitord_plugin.py
+++ b/packages/pegasus-python/test/test_monitord_plugin.py
@@ -15,6 +15,7 @@ from Pegasus.monitoring.plugin import (
     MONITORD_PLUGIN_ENTRY_POINT_GROUP,
     MonitordEventPlugin,
     MonitordPluginManager,
+    _PluginWorker,
     enabled_plugin_names,
 )
 from Pegasus.tools import properties
@@ -1543,3 +1544,175 @@ def test_factory_threads_restart_through_multiplex_to_plugins(monkeypatch, tmp_p
     assert isinstance(host, eo.PluginHostEventSink)
     assert host._manager._workers[0][1].restart_seen is True
     sink.close()
+
+
+# --------------------------------------------------------------------------- #
+# concurrency invariants pinned directly (load-bearing for any future
+# asynchrony work; previously only inferred indirectly)
+# --------------------------------------------------------------------------- #
+
+
+class MutexProbePlugin(MonitordEventPlugin):
+    """
+    Gated first handle_event plus a thread-ident audit of both hooks, to pin
+    the handle_event/tick mutual-exclusion contract directly: both hooks must
+    only ever run on the one worker thread, and no tick may fire while the
+    worker is provably parked inside handle_event.
+    """
+
+    def __init__(self):
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self.ticks = []
+        self.hook_threads = set()
+
+    def handle_event(self, event, kw):
+        self.hook_threads.add(threading.get_ident())
+        self.entered.set()
+        self.release.wait(timeout=5)
+
+    def tick(self):
+        self.hook_threads.add(threading.get_ident())
+        self.ticks.append(time.monotonic())
+
+
+class _PutRecordingQueue(queue.Queue):
+    """queue.Queue that records the thread ident of every enqueue
+    (put_nowait routes through put, so both are captured)."""
+
+    def __init__(self, maxsize=0):
+        super().__init__(maxsize)
+        self.put_idents = []
+
+    def put(self, item, block=True, timeout=None):
+        self.put_idents.append(threading.get_ident())
+        return super().put(item, block=block, timeout=timeout)
+
+
+class _ThreadRecordingProbe:
+    """Payload value that records the thread ident of every deepcopy."""
+
+    def __init__(self):
+        self.copy_idents = []
+
+    def __deepcopy__(self, memo):
+        self.copy_idents.append(threading.get_ident())
+        return self
+
+
+def test_tick_never_runs_concurrently_with_handle_event(monkeypatch):
+    _patch_entry_points(monkeypatch, {"mx": MutexProbePlugin})
+    props = _props(
+        {
+            "pegasus.monitord.plugins.mx.enabled": "true",
+            "pegasus.monitord.plugins.mx.tick_interval": "0.02",
+        }
+    )
+    mgr = MonitordPluginManager(props)
+    mgr.discover_and_start()
+    plugin = mgr._workers[0][1]
+
+    # ticking is provably live before the handler is pinned
+    assert _wait_for(lambda: len(plugin.ticks) >= 1)
+
+    mgr.dispatch("stampede.block", {})
+    assert plugin.entered.wait(timeout=2)
+    ticks_before = len(plugin.ticks)
+    # the worker is parked inside handle_event; a concurrent tick would have
+    # to fire from some other thread. Several intervals of silence prove the
+    # exclusion (negative assertion, same style as the no-tick-after-sentinel
+    # check in test_stop_all_drains_and_joins_ticking_plugin).
+    time.sleep(0.15)
+    assert len(plugin.ticks) == ticks_before
+    plugin.release.set()
+    # ticks resume once the handler returns
+    assert _wait_for(lambda: len(plugin.ticks) > ticks_before)
+    mgr.stop_all()
+    # both hooks only ever ran on the single worker thread
+    assert len(plugin.hook_threads) == 1
+    assert threading.get_ident() not in plugin.hook_threads
+
+
+def test_single_producer_all_enqueues_on_dispatching_thread():
+    """
+    Pins the single-producer invariant the drop-oldest bounded retry relies
+    on: every queue put (events, evict-then-requeue, shutdown sentinel) and
+    every payload snapshot happens synchronously on the dispatching thread;
+    the worker thread only ever get()s.
+    """
+    plugin = GatedRecordingPlugin()
+    worker = _PluginWorker(
+        "sp",
+        plugin,
+        queue_size=1,
+        join_timeout=2.0,
+        overflow_policy="drop-oldest",
+    )
+    recording = _PutRecordingQueue(maxsize=1)
+    worker._queue = recording  # swapped before start(); _run reads it live
+    worker.start()
+    producer = threading.get_ident()
+    probe = _ThreadRecordingProbe()
+
+    # e0 is dequeued and pins the worker inside handle_event
+    worker.submit("stampede.e0", {"probe": probe})
+    assert plugin.entered.wait(timeout=2)
+    # e1 fills the single queue slot; e2 forces the drop-oldest bounded
+    # retry (get_nowait eviction + put_nowait requeue) on this thread
+    worker.submit("stampede.e1", {"probe": probe})
+    worker.submit("stampede.e2", {"probe": probe})
+    # the drop is already visible to the producer when submit returns --
+    # the counter write happened synchronously on this thread
+    assert worker._dropped == 1
+
+    plugin.release.set()
+    assert worker.close() is True
+
+    # drop-oldest kept the newest event
+    assert [e for e, _kw in plugin.events] == ["stampede.e0", "stampede.e2"]
+    # every enqueue attempt -- e0, e1, e2's rejected overflow put, e2's
+    # requeue after eviction, and the sentinel -- came from the dispatching
+    # thread; the worker thread never put anything
+    assert set(recording.put_idents) == {producer}
+    assert len(recording.put_idents) == 5
+    # every payload snapshot ran synchronously on the dispatching thread
+    assert set(probe.copy_idents) == {producer}
+
+
+# --------------------------------------------------------------------------- #
+# startup-failure cleanup must not race a still-running worker
+# --------------------------------------------------------------------------- #
+
+
+def test_cleanup_failed_start_skips_stop_when_worker_wedged(caplog):
+    plugin = StopRecordingBlockingPlugin()
+    worker = _PluginWorker("wedge", plugin, join_timeout=0.01)
+    worker.start()
+    worker.submit("stampede.block", {})
+    assert plugin.entered.wait(timeout=2)
+
+    mgr = MonitordPluginManager(_props())
+    with caplog.at_level(logging.WARNING):
+        mgr._cleanup_failed_start("wedge", plugin, worker, 0.01)
+
+    # stop() must be skipped, exactly like stop_all does for a wedged worker
+    assert plugin.stopped is False
+    assert any(
+        "skipping plugin 'wedge' stop() during startup cleanup" in r.message
+        for r in caplog.records
+    )
+    plugin.release.set()
+    assert _wait_for(lambda: not worker._thread.is_alive())
+
+
+def test_cleanup_failed_start_stops_plugin_after_worker_exit():
+    plugin = StopRecordingBlockingPlugin()
+    worker = _PluginWorker("clean", plugin, join_timeout=2.0)
+    worker.start()
+
+    mgr = MonitordPluginManager(_props())
+    mgr._cleanup_failed_start("clean", plugin, worker, 2.0)
+
+    # idle worker exits within the bound, so cleanup still runs stop()
+    assert plugin.stopped is True
+    assert not worker._thread.is_alive()

--- a/packages/pegasus-python/test/test_monitord_plugin.py
+++ b/packages/pegasus-python/test/test_monitord_plugin.py
@@ -142,6 +142,25 @@ class BlockingStartPlugin(MonitordEventPlugin):
         self.stopped = True
 
 
+class BlockingConstructorPlugin(MonitordEventPlugin):
+    instances = []
+    constructor_entered = threading.Event()
+    release_constructor = threading.Event()
+    started = 0
+
+    def __init__(self):
+        type(self).constructor_entered.set()
+        type(self).release_constructor.wait(timeout=5)
+        self.stopped = False
+        type(self).instances.append(self)
+
+    def start(self, props=None):
+        type(self).started += 1
+
+    def stop(self):
+        self.stopped = True
+
+
 class FlakyHandlePlugin(MonitordEventPlugin):
     """Raises on a designated event, records the rest."""
 
@@ -343,6 +362,89 @@ def test_start_timeout_skips_plugin_and_late_cleans_up(monkeypatch):
 
     mgr.stop_all()
     assert mgr._workers == []
+
+
+def test_start_timeout_bounds_constructor_and_late_cleans_up(monkeypatch):
+    BlockingConstructorPlugin.instances = []
+    BlockingConstructorPlugin.constructor_entered = threading.Event()
+    BlockingConstructorPlugin.release_constructor = threading.Event()
+    BlockingConstructorPlugin.started = 0
+    _patch_entry_points(
+        monkeypatch,
+        {"slowctor": BlockingConstructorPlugin, "good": RecordingPlugin},
+    )
+    props = _props(
+        {
+            "pegasus.monitord.plugins.slowctor.enabled": "true",
+            "pegasus.monitord.plugins.slowctor.start_timeout": "0.01",
+            "pegasus.monitord.plugins.good.enabled": "true",
+        }
+    )
+    mgr = MonitordPluginManager(props)
+
+    start = time.monotonic()
+    assert mgr.discover_and_start() == 1
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0, f"discover_and_start blocked for {elapsed:.2f}s"
+    assert BlockingConstructorPlugin.constructor_entered.is_set()
+    assert isinstance(mgr._workers[0][1], RecordingPlugin)
+
+    BlockingConstructorPlugin.release_constructor.set()
+    assert _wait_for(lambda: len(BlockingConstructorPlugin.instances) == 1)
+    late = BlockingConstructorPlugin.instances[0]
+    assert BlockingConstructorPlugin.started == 0
+    assert _wait_for(lambda: late.stopped is True)
+
+    mgr.stop_all()
+
+
+def test_start_timeout_bounds_entry_point_load(monkeypatch):
+    load_entered = threading.Event()
+    release_load = threading.Event()
+    load_returned = threading.Event()
+    CountingStartPlugin.started = 0
+    CountingStartPlugin.stopped = 0
+
+    class BlockingLoadEntryPoint(_FakeEntryPoint):
+        def load(self):
+            load_entered.set()
+            release_load.wait(timeout=5)
+            load_returned.set()
+            return super().load()
+
+    eps = [
+        BlockingLoadEntryPoint("slowload", CountingStartPlugin),
+        _FakeEntryPoint("good", RecordingPlugin),
+    ]
+    monkeypatch.setattr(
+        importlib.metadata,
+        "entry_points",
+        lambda: _FakeEntryPoints(eps),
+    )
+    props = _props(
+        {
+            "pegasus.monitord.plugins.slowload.enabled": "true",
+            "pegasus.monitord.plugins.slowload.start_timeout": "0.01",
+            "pegasus.monitord.plugins.good.enabled": "true",
+        }
+    )
+    mgr = MonitordPluginManager(props)
+
+    start = time.monotonic()
+    assert mgr.discover_and_start() == 1
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0, f"discover_and_start blocked for {elapsed:.2f}s"
+    assert load_entered.is_set()
+    assert isinstance(mgr._workers[0][1], RecordingPlugin)
+
+    release_load.set()
+    assert load_returned.wait(timeout=1)
+    assert CountingStartPlugin.started == 0
+    assert CountingStartPlugin.stopped == 0
+
+    mgr.stop_all()
 
 
 def test_entry_point_discovery_error_is_graceful(monkeypatch):


### PR DESCRIPTION
## **DO NOT MERGE UNTIL DISCUSSED**

@vahi , @mayani - See subsequent comments for testing details

---

Layers asynchrony onto the monitord plugin system (#2194) in eight commits on top of `monitord-plugin-system` @ 87129bdb5. Targets the plugin-system branch so the diff shows only the async delta; adopting this PR means merging these capabilities into the plugin system before it goes to `main`.

## What it enables

**Parallel plugin lifecycle** (21bd8da33). `start()` and `stop()` of multiple plugins now fan out concurrently via plain daemon threads (`_fan_out`), so one slow plugin no longer serializes bootstrap or shutdown of the others. Per-plugin timeout bounds are unchanged; worst-case wall time drops from sum-of-timeouts to max-of-timeouts.

**Shape-aware payload snapshot** (49fced37f). `_PluginWorker.submit` replaces blanket `copy.deepcopy(kw)` with `_snapshot_payload`: exact-type scalars pass by reference, only nested mutable values are deep-copied. Semantics are identical (deepcopy returns atomics by identity anyway); the per-event copy cost drops for the common flat-payload case. A single shared memo seeded with `{id(kw): snapshot}` preserves cross-value aliasing.

**Opt-in native-async plugins** (f063d7b02). `handle_event`, `tick`, and `stop` may be coroutine functions (detected via `inspect.iscoroutinefunction`); each worker thread runs its own private event loop. A new `.event_timeout` property (default `0` = off) bounds a single event's handling; timed-out tasks are cancelled, counted, and reported once at `close()`. Async `stop()` is cancelled at `join_timeout` with one extra grace join.

**Out-of-process guidance** (33753982b). Docs steer native/untrusted consumers to the AMQP sink or file-tail patterns instead of in-process plugins.

**Concurrency pre-work** (7d59a01ab). Direct tests pin the handle_event/tick mutual-exclusion and single-producer invariants that were previously only indirectly covered; monitord installs a SIGTERM handler (a plain `kill` now drains plugins instead of skipping the atexit path); `_cleanup_failed_start` skips `stop()` when the worker didn't exit — never racing `stop()` against a live handler.

Round-1 and round-2 review fixes are included (47b34e966, a343a37f9, e893905ee): async-stop cancellation no longer races the outer join, `CancelledError` (a `BaseException`) is caught explicitly in `_handle`/`_tick`, the snapshot memo bug is fixed, monitord closes the sink when replay purge fails, and the complete bootstrap (entry-point `load()` + constructor + `start()` + worker spin-up) sits inside the bounded helper.

## Compatibility

Invisible to existing synchronous plugins — no API or threading-contract change; existing plugin authors need zero modifications (verified against the wfevents plugins). Sync plugins keep the same thread affinity and one-event-at-a-time ordering.

## Gotchas if adopted

- **Async ≠ parallel events.** An async plugin's coroutines run on a private per-worker loop, still one event at a time. A coroutine that never awaits blocks its worker exactly like a slow sync handler; the win is timeout/cancellation control, not throughput.
- **`event_timeout` is off by default**, and enabling it means cancelled work: a timed-out handler receives `CancelledError` mid-flight and the event is effectively dropped (counted in the close-time report, not retried). Plugins opting in must be cancellation-safe.
- **A sync `handle_event` that returns a coroutine** (an `async def` not detected because it's wrapped, or a forgotten `await`) is closed and logged once rather than executed — a quiet failure mode to know about when debugging a plugin that "runs but does nothing."
- **Shutdown can take up to ~2× `join_timeout`** per async plugin: cancellation at `join_timeout`, then one grace join for the cancelled task to unwind.
- **Lifecycle fan-out deliberately uses bare daemon threads, not `ThreadPoolExecutor`** — the executor's atexit hook interacts badly with monitord's own atexit-driven shutdown. Keep it that way if refactoring.
- **The scalar pass-by-reference allowlist is exact-type** (`type(v) in ...`), so subclasses of `str`/`int`/etc. still get deep-copied. Don't "optimize" it to `isinstance` — that would leak mutable subclass instances by reference.
- **Two commits here overlap the system branch**: a343a37f9/e893905ee are the same fixes as `monitord-plugin-system`'s 16774555a/3316ddd41 (and 7d59a01ab contains the cleanup-stop-race fix ported there as 3b3d83821). Merging should be textually clean, but review the overlap rather than assuming.

## Testing

Plugin suite grows 56 → 81 tests (barrier tests deadlock under the old serial lifecycle, timeout/cancellation paths, snapshot machinery pins including a patched-`copy.deepcopy` probe that fails if scalars ever re-enter the deepcopy path). Full `pegasus-python` package via `tox -e py314`: 482 passed. `doc/sphinx/reference-guide/monitoring.rst` updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
