### PR TITLE
Add pegasus-em triggers command to list ensemble triggers

### DIFF
--- a/doc/sphinx/manpages/pegasus-em.rst
+++ b/doc/sphinx/manpages/pegasus-em.rst
@@ -61,6 +61,9 @@ Commands
 **file-pattern-trigger** *ENSEMBLE* *TRIGGER* *INTERVAL* *WORKFLOW_SCRIPT* *FILE_PATTERN* [FILE_PATTERN ...] [-t TIMEOUT] [--args ARG1 [ARG2 ...]]
    Start a timed, file pattern workflow trigger.
 
+**triggers** *ENSEMBLE* [-l]
+   List the triggers in an ensemble.
+
 Common Options
 ==============
 
@@ -85,6 +88,14 @@ Create and Config Options
 
 Workflows Options
 =================
+
+**-l**; \ **--long**
+   Use long listing format.
+
+
+
+Triggers Options
+================
 
 **-l**; \ **--long**
    Use long listing format.

--- a/packages/pegasus-python/src/Pegasus/service/ensembles/commands.py
+++ b/packages/pegasus-python/src/Pegasus/service/ensembles/commands.py
@@ -666,7 +666,55 @@ class FilePatternTriggerCommand(EnsembleClientCommand):
 
 # TODO: StopTriggerCommand
 
-# TODO: ListTriggersCommand
+
+class ListTriggersCommand(EnsembleClientCommand):
+    description = "List triggers in an ensemble"
+    usage = "Usage: %prog triggers [options] ENSEMBLE"
+
+    def __init__(self):
+        EnsembleClientCommand.__init__(self)
+        self.parser.add_option(
+            "-l",
+            "--long",
+            action="store_true",
+            dest="long",
+            default=False,
+            help="Show detailed output",
+        )
+
+    def run(self):
+        if len(self.args) == 0:
+            self.parser.error("Specify ENSEMBLE")
+        if len(self.args) > 1:
+            self.parser.error("Invalid argument")
+
+        response = self.get(f"/ensembles/{self.args[0]}/triggers")
+
+        result = response.json()
+
+        if len(result) == 0:
+            return
+
+        if self.options.long:
+            for t in result:
+                print("Name:".ljust(15), t["name"])
+                print("Type:".ljust(15), t["type"])
+                print("State:".ljust(15), t["state"])
+                print("Workflow:".ljust(15), t["workflow"]["script"])
+                print(
+                    "Workflow Args:".ljust(15),
+                    " ".join(str(a) for a in (t["workflow"]["args"] or [])),
+                )
+                for key, value in (t["args"] or {}).items():
+                    print(f"{key.replace('_', ' ').title()}:".ljust(15), value)
+                print()
+        else:
+            print(f"{'NAME':<20} {'TYPE':<14} {'STATE':<10} {'WORKFLOW SCRIPT':<30}")
+            for t in result:
+                print(
+                    f"{t['name']:<20} {t['type']:<14} {t['state']:<10} "
+                    f"{t['workflow']['script']:<30}"
+                )
 
 
 # ------------------------------------------------------------------------------
@@ -690,6 +738,7 @@ class EnsembleCommand(CompoundCommand):
         ("priority", PriorityCommand),
         ("cron-trigger", CronTriggerCommand),
         ("file-pattern-trigger", FilePatternTriggerCommand),
+        ("triggers", ListTriggersCommand),
     ]
     aliases = {
         "c": "create",
@@ -698,6 +747,7 @@ class EnsembleCommand(CompoundCommand):
         "sub": "submit",
         "an": "analyze",
         "st": "status",
+        "t": "triggers",
     }
 
 

--- a/packages/pegasus-python/test/service/ensembles/test_commands.py
+++ b/packages/pegasus-python/test/service/ensembles/test_commands.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -10,7 +10,9 @@ from Pegasus.service.ensembles.commands import (
     EM_PORT_MIN,
     CronTriggerCommand,
     FilePatternTriggerCommand,
+    ListTriggersCommand,
     _compute_em_port,
+    emapp,
 )
 
 
@@ -164,3 +166,106 @@ class TestFilePatternTriggerCommand:
         Pegasus.service.ensembles.commands.FilePatternTriggerCommand.post.assert_called_once_with(
             "/ensembles/ensemble/triggers/file_pattern", data=expected_request_data
         )
+
+
+class TestListTriggersCommand:
+    @pytest.fixture(autouse=True)
+    def configure_credentials(self, mocker):
+        # ListTriggersCommand relies on EnsembleClientCommand's real __init__ to
+        # build self.parser (optparse), so unlike the argparse-based trigger
+        # creation commands, EnsembleClientCommand itself can't be mocked out here.
+        mocker.patch.dict(emapp.config, {"USERNAME": "user", "PASSWORD": "pass"})
+
+    def _mock_get(self, mocker, triggers):
+        response = MagicMock()
+        response.json.return_value = triggers
+        return mocker.patch(
+            "Pegasus.service.ensembles.commands.ListTriggersCommand.get",
+            return_value=response,
+        )
+
+    def test_short_format(self, mocker, capsys):
+        get = self._mock_get(
+            mocker,
+            [
+                {
+                    "name": "trigger1",
+                    "type": TriggerType.CRON.value,
+                    "state": "RUNNING",
+                    "workflow": {"script": "/workflow.py", "args": []},
+                    "args": {"interval": 10, "timeout": None},
+                }
+            ],
+        )
+
+        cmd = ListTriggersCommand()
+        cmd.parse(["ensemble"])
+        cmd.run()
+
+        get.assert_called_once_with("/ensembles/ensemble/triggers")
+        out = capsys.readouterr().out
+        assert "trigger1" in out
+        assert "RUNNING" in out
+        assert "/workflow.py" in out
+
+    def test_long_format(self, mocker, capsys):
+        self._mock_get(
+            mocker,
+            [
+                {
+                    "name": "trigger1",
+                    "type": TriggerType.CRON.value,
+                    "state": "RUNNING",
+                    "workflow": {"script": "/workflow.py", "args": ["arg1"]},
+                    "args": {"interval": 10, "timeout": 20},
+                }
+            ],
+        )
+
+        cmd = ListTriggersCommand()
+        cmd.parse(["ensemble", "-l"])
+        cmd.run()
+
+        out = capsys.readouterr().out
+        assert "trigger1" in out
+        assert "/workflow.py" in out
+        assert "arg1" in out
+        assert "10" in out
+        assert "20" in out
+
+    def test_long_format_with_null_workflow_args_and_args(self, mocker, capsys):
+        self._mock_get(
+            mocker,
+            [
+                {
+                    "name": "trigger1",
+                    "type": TriggerType.CRON.value,
+                    "state": "READY",
+                    "workflow": {"script": "/workflow.py", "args": None},
+                    "args": None,
+                }
+            ],
+        )
+
+        cmd = ListTriggersCommand()
+        cmd.parse(["ensemble", "-l"])
+        cmd.run()
+
+        out = capsys.readouterr().out
+        assert "trigger1" in out
+        assert "/workflow.py" in out
+
+    def test_empty_result_prints_nothing(self, mocker, capsys):
+        self._mock_get(mocker, [])
+
+        cmd = ListTriggersCommand()
+        cmd.parse(["ensemble"])
+        cmd.run()
+
+        assert capsys.readouterr().out == ""
+
+    def test_requires_ensemble_argument(self):
+        cmd = ListTriggersCommand()
+        cmd.parse([])
+        with pytest.raises(SystemExit):
+            cmd.run()


### PR DESCRIPTION
## Summary

- Adds `pegasus-em triggers ENSEMBLE [-l/--long]` (alias `t`), which calls the existing `GET /ensembles/<ensemble>/triggers` REST endpoint to show each trigger's name/type/state (and full detail with `-l`: workflow script/args, interval, timeout, file patterns).
- Closes the long-standing `# TODO: ListTriggersCommand` marker in `commands.py`. The neighboring `# TODO: StopTriggerCommand` and the pre-existing, unregistered `HoldCommand` dead code are intentionally left untouched — separate scope.
- Updates the `pegasus-em` manpage with the new command.
- The backend (REST endpoint + DB query) already existed and was already tested; this PR only adds the missing CLI command that calls it.

## Test plan

- [x] Unit tests added in `test/service/ensembles/test_commands.py` (short format, long format, null workflow-args/args edge case, empty result, missing-ENSEMBLE-argument error) — all passing via `tox -e py310`.
- [x] Full `pegasus-python` package test suite passes.
- [x] Lint (pre-commit / ruff) clean.
- [ ] e2e — intentionally **not** run. The ensemble manager has no e2e/workflow-level test coverage, so there's nothing an e2e run would exercise for this change (confirmed with the issue requester).

## Skipped review findings

Autonomous review (simplify + Codex adversarial) surfaced a few items that were deliberately left as-is:

- `commands.py` — the "exactly one arg" validation pattern (`len(self.args)==0`/`>1`) is duplicated across ~7 sibling `EnsembleClientCommand` subclasses, including the new one; a shared helper would touch the whole file, out of scope here.
- `commands.py` — `if len(result) == 0: return` duplicates the identical early-exit already in `WorkflowsCommand`; matches existing house style.
- `views.py` (`route_list_triggers`) — returns `200 []` for a nonexistent ensemble instead of 404, unlike the workflow-list route. Pre-existing behavior with an existing passing test asserting it; unrelated to this change, worth a separate issue if wanted.

Closes #1791