### PR TITLE
chore(planner): throw error for container use in sharedfs mode

### DIFF
--- a/src/edu/isi/pegasus/planner/code/GridStartFactory.java
+++ b/src/edu/isi/pegasus/planner/code/GridStartFactory.java
@@ -14,6 +14,7 @@
 package edu.isi.pegasus.planner.code;
 
 import edu.isi.pegasus.common.util.DynamicLoader;
+import edu.isi.pegasus.planner.catalog.transformation.classes.Container;
 import edu.isi.pegasus.planner.classes.ADag;
 import edu.isi.pegasus.planner.classes.AggregatedJob;
 import edu.isi.pegasus.planner.classes.Job;
@@ -392,9 +393,27 @@ public class GridStartFactory {
             }
         }
 
-        return (propValue == null)
-                ? GridStartFactory.DEFAULT_GRIDSTART_MODE
-                : propValue; // return what was specified in the properties file.
+        String gridstart =
+                (propValue == null)
+                        ? GridStartFactory.DEFAULT_GRIDSTART_MODE
+                        : propValue; // return what was specified in the properties file.
+
+        // GH-2188 containers are only supported when the job is launched via PegasusLite
+        // i.e. data configuration is condorio or nonsharedfs. sharedfs mode does not wrap
+        // jobs with PegasusLite, so a job with a container attached cannot be honored.
+        Container container = job.getContainer();
+        if (container != null && !gridstart.equalsIgnoreCase("PegasusLite")) {
+            throw new GridStartFactoryException(
+                    "Container "
+                            + container.getName()
+                            + " specified for job "
+                            + job.getID()
+                            + " but the job is not set to be launched via PegasusLite."
+                            + " Containers are only supported when the data configuration is"
+                            + " condorio or nonsharedfs, not sharedfs.");
+        }
+
+        return gridstart;
     }
 
     /**

--- a/test/junit/edu/isi/pegasus/planner/code/GridStartFactoryTest.java
+++ b/test/junit/edu/isi/pegasus/planner/code/GridStartFactoryTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import edu.isi.pegasus.planner.catalog.transformation.classes.Container;
 import edu.isi.pegasus.planner.classes.Job;
 import edu.isi.pegasus.planner.common.PegasusConfiguration;
 import edu.isi.pegasus.planner.common.PegasusProperties;
@@ -126,6 +127,29 @@ public class GridStartFactoryTest {
         TestGridStartFactory factory = configuredFactory(null);
         Job job = new Job();
         job.setDataConfiguration(PegasusConfiguration.NON_SHARED_FS_CONFIGURATION_VALUE);
+
+        assertThat(factory.shortNameFor(job), is("PegasusLite"));
+    }
+
+    @Test
+    public void testGetGridStartShortNameThrowsWhenContainerUsedWithSharedFs() throws Exception {
+        TestGridStartFactory factory = configuredFactory(null);
+        Job job = new Job();
+        job.setDataConfiguration(PegasusConfiguration.SHARED_FS_CONFIGURATION_VALUE);
+        job.setContainer(new Container("centos-pegasus"));
+
+        GridStartFactoryException exception =
+                assertThrows(GridStartFactoryException.class, () -> factory.shortNameFor(job));
+
+        assertThat(exception.getMessage().contains("centos-pegasus"), is(true));
+    }
+
+    @Test
+    public void testGetGridStartShortNameAllowsContainerForNonSharedFs() throws Exception {
+        TestGridStartFactory factory = configuredFactory(null);
+        Job job = new Job();
+        job.setDataConfiguration(PegasusConfiguration.NON_SHARED_FS_CONFIGURATION_VALUE);
+        job.setContainer(new Container("centos-pegasus"));
 
         assertThat(factory.shortNameFor(job), is("PegasusLite"));
     }


### PR DESCRIPTION
## Summary
- `GridStartFactory.getGridStartShortName()` previously fell through to `Kickstart` for jobs whose data configuration is `sharedfs` (or unset), silently ignoring any container attached to the job, since `Kickstart` has no container-wrapping support (only `PegasusLite` does).
- Now throws `GridStartFactoryException` when a job has a container attached but is not set to be launched via `PegasusLite`, so users get an explicit planning-time error instead of a workflow that silently runs uncontainerized.
- Added unit tests: throws for container + `sharedfs`, allows container + `nonsharedfs` (PegasusLite path).

## Skipped review findings
- Validation is placed at code-generation time (`GridStartFactory`) rather than job-assembly time (`InterPoolEngine`) — deliberate, mirrors the existing GH-2074/PM-1968 check in the same method and is directly unit-testable via the existing test harness.
- Error message uses string concatenation rather than `String.format()` — stylistic, not applied.
- The two new test methods could be collapsed into a single `@ParameterizedTest` — stylistic, not applied.
- Edge case: a non-compute job (stage-in/out/cleanup) with a container in the TC plus an explicit `pegasus.gridstart=Kickstart` property would also throw; such a configuration is invalid regardless, so left as-is.

## Test plan
- [x] `GridStartFactoryTest` (15 tests, incl. 2 new) pass locally
- [ ] e2e — to be triggered manually

Closes #2188